### PR TITLE
API 공통 응답 구조 및 Security CORS 초기 세팅 추가

### DIFF
--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -1,0 +1,63 @@
+package com.playlist.plitter.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Value("${spring.cors.allowed_origins}")
+    private String allowedOrigins;
+
+    /* TODO: JWTUtil 주입 */
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                );
+
+        /* TODO: JWT 필터 및 OAuth2 설정 */
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(Collections.singletonList(allowedOrigins));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setMaxAge(3600L);
+        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/playlist/plitter/global/dto/ResponseDto.java
+++ b/src/main/java/com/playlist/plitter/global/dto/ResponseDto.java
@@ -1,0 +1,21 @@
+package com.playlist.plitter.global.dto;
+
+public record ResponseDto<D>(
+        String code,
+        String message,
+        D content
+) {
+    private static final String SUCCESS_CODE = "SUCCESS";
+
+    public static <D> ResponseDto<D> ofSuccess(SuccessMessage success, D data) {
+        return new ResponseDto<>(SUCCESS_CODE, success.getMessage(), data);
+    }
+
+    public static ResponseDto<Void> ofSuccess(SuccessMessage success) {
+        return new ResponseDto<>(SUCCESS_CODE, success.getMessage(), null);
+    }
+
+    public static ResponseDto<Void> ofFailure(String errorCode, String message) {
+        return new ResponseDto<>(errorCode, message, null);
+    }
+}

--- a/src/main/java/com/playlist/plitter/global/dto/SuccessMessage.java
+++ b/src/main/java/com/playlist/plitter/global/dto/SuccessMessage.java
@@ -1,0 +1,19 @@
+package com.playlist.plitter.global.dto;
+
+public enum SuccessMessage {
+    OPERATION_SUCCESS("요청이 성공적으로 처리되었습니다."),
+    CREATE_SUCCESS("등록이 완료되었습니다."),
+    UPDATE_SUCCESS("수정이 완료되었습니다."),
+    DELETE_SUCCESS("삭제가 완료되었습니다.");
+
+
+    private final String message;
+
+    SuccessMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/playlist/plitter/global/exception/ApiException.java
+++ b/src/main/java/com/playlist/plitter/global/exception/ApiException.java
@@ -1,0 +1,15 @@
+package com.playlist.plitter.global.exception;
+
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ApiException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/playlist/plitter/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/playlist/plitter/global/exception/ApiExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.playlist.plitter.global.exception;
+
+import com.playlist.plitter.global.dto.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ResponseDto<Void>> handleApiException(ApiException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ResponseDto.ofFailure(errorCode.getErrorCode(),errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseDto<Void>> handleGeneralException(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDto.ofFailure("INTERNAL_SERVER_ERROR", "An unexpected error occurred"));
+    }
+}

--- a/src/main/java/com/playlist/plitter/global/exception/ErrorCode.java
+++ b/src/main/java/com/playlist/plitter/global/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.playlist.plitter.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getMessage();
+    String getErrorCode();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
-spring.application.name=plitter
+spring.application.name=plitter-be
+spring.cors.allowed_origins=http://localhost:3000
+spring.datasource.url=jdbc:h2:mem:test
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

## 📌 관련 이슈
<!-- 연결된 이슈 -->
- closed: #1 

## 📝 작업 내용
<!-- 수정/추가한 내용 -->
### 🛠️ 주요 변경 사항 및 클래스 설명

**1️⃣ 전역 설정 (`global/config`)**
* **`SecurityConfig.java`**
  * Spring Security의 초기 세팅을 담당합니다.
  * 세션 정책을 `STATELESS`로 설정하고 폼 로그인을 비활성화했습니다.
  * 프론트엔드(`localhost:3000`)와의 원활한 통신을 위해 필터 단에 CORS 설정을 추가하여 Preflight 이슈를 방지했습니다. _(현재 테스트를 위해 임시로 모든 요청 `permitAll` 처리)_

**2️⃣ 공통 응답 DTO (`global/dto`)**
* **`ResponseDto.java`**
  * API 응답 공통 DTO입니다. Java `record`를 활용하여 불변 객체로 구현했습니다.
  * 생성자를 직접 호출하지 않고 `ofSuccess`, `ofFailure` 등의 정적 팩토리 메서드를 통해서만 생성하도록 캡슐화했습니다.
* **`SuccessMessage.java`**
  * API 요청 성공 시 사용할 메시지들을 모아둔 Enum 클래스입니다. (예: `OPERATION_SUCCESS`, `CREATE_SUCCESS`)

**3️⃣ 전역 예외 처리 (`global/exception`)**
* **`ErrorCode.java`** (인터페이스)
  * 확장을 고려한 OCP 설계입니다. 향후 각 도메인별로 에러 코드 Enum을 만들 때 이 인터페이스를 상속받아 구현하면 됩니다.
* **`ApiException.java`**
  * 비즈니스 로직 처리 중 의도적으로 발생시키는 커스텀 예외 클래스입니다. `ErrorCode`를 품고 던져집니다.
* **`ApiExceptionHandler.java`**
  * `@RestControllerAdvice`를 활용하여 프로젝트 전역에서 터지는 예외를 잡는 컨트롤러입니다.
  * `ApiException`은 우리가 의도한 상태 코드와 메시지로 응답하고, 예측하지 못한 `Exception`은 500 에러 처리로 구축했습니다.

**4️⃣ 환경 변수**
* **`application.properties`**
  * 프론트엔드 CORS 허용 도메인(`localhost:3000`) 및 초기 테스트용 H2 인메모리 DB 연결 설정을 추가했습니다.
  * 이후 `secret-application.properties`는 따로 노션에 공유하도록 하겠습니다.
</br>

### 💻 사용 예시

앞으로 도메인 로직을 개발하실 때 아래 형식에 맞춰 `ErrorCode`를 커스텀하여 사용해 주시면 됩니다!

**1️⃣ 도메인별 커스텀 ErrorCode 정의 예시 (Enum)**
`ErrorCode` 인터페이스를 상속받아 각 도메인(예: Music, Playlist)에 맞는 에러를 선언합니다.
```java
public enum MusicErrorCode implements ErrorCode {
    MUSIC_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 곡을 찾을 수 없습니다.", "MUSIC_NOT_FOUND"),
    PLAYLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 플레이리스트를 찾을 수 없습니다.", "PLAYLIST_NOT_FOUND"),
    INVALID_MUSIC_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 음악 ID입니다.", "INVALID_MUSIC_ID");

    private final HttpStatus httpStatus;
    private final String message;
    private final String errorCode;

    MusicErrorCode(final HttpStatus httpStatus, final String message, final String errorCode) {
        this.httpStatus = httpStatus;
        this.message = message;
        this.errorCode = errorCode;
    }

    @Override
    public HttpStatus getHttpStatus() { return httpStatus; }

    @Override
    public String getMessage() { return message; }

    @Override
    public String getErrorCode() { return errorCode; }
}
```

**2️⃣ 서비스 로직에서 예외 발생시키기**
만들어둔 Enum 코드를 ApiException에 담아서 던지면 ApiExceptionHandler가 자동으로 잡아서 클라이언트에게 JSON으로 응답합니다.
```java
if (music == null) {
    throw new ApiException(MusicErrorCode.MUSIC_NOT_FOUND); 
}
```

**3️⃣ 정상 응답 반환 (Controller)**
```java
@GetMapping("/api/musics/{musicId}")
public ResponseEntity<ResponseDto<MusicDto>> getMusic(@PathVariable Long musicId) {
    MusicDto musicDto = musicService.getMusic(musicId);
    return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, musicDto));
}
```

## 🔎 고민한 내용
<!-- 해당 PR중 고민한 내용 -->

## 💬 기타 참고 사항
<!-- 리뷰어에게 전달할 내용 -->
