### PR TITLE
유저 인증 예외 경로 정리 & 프론트 요청 사항 반영

### DIFF
--- a/src/main/java/com/playlist/plitter/auth/kakao/controller/KakaoController.java
+++ b/src/main/java/com/playlist/plitter/auth/kakao/controller/KakaoController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.net.URI;
 
 @RestController
-@RequestMapping("/auth/kakao")
+@RequestMapping({"/auth/kakao", "/api/auth/kakao"})
 @RequiredArgsConstructor
 public class KakaoController {
 

--- a/src/main/java/com/playlist/plitter/auth/kakao/controller/KakaoController.java
+++ b/src/main/java/com/playlist/plitter/auth/kakao/controller/KakaoController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.net.URI;
 
 @RestController
-@RequestMapping({"/auth/kakao", "/api/auth/kakao"})
+@RequestMapping({"/api/auth/kakao"})
 @RequiredArgsConstructor
 public class KakaoController {
 

--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/kakao/**").permitAll()
                         .requestMatchers("/auth/logout").permitAll()
+                        .requestMatchers("/api/tracks/search").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/kakao/**").permitAll()
                         .requestMatchers("/api/auth/kakao/**").permitAll()
+                        .requestMatchers("/api/auth/guest").permitAll()
                         .requestMatchers("/auth/logout").permitAll()
                         .requestMatchers("/api/tracks/search").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/kakao/**").permitAll()
+                        .requestMatchers("/api/auth/kakao/**").permitAll()
                         .requestMatchers("/auth/logout").permitAll()
                         .requestMatchers("/api/tracks/search").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,6 +48,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/kakao/**").permitAll()
                         .requestMatchers("/api/auth/guest").permitAll()
                         .requestMatchers("/auth/logout").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/playlists/*/recommendations").permitAll()
                         .requestMatchers("/api/tracks/search").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/playlist/plitter/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/playlist/plitter/global/exception/ApiExceptionHandler.java
@@ -19,6 +19,8 @@ public class ApiExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResponseDto<Void>> handleGeneralException(Exception ex) {
+        ex.printStackTrace();
+
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ResponseDto.ofFailure("INTERNAL_SERVER_ERROR", "An unexpected error occurred"));

--- a/src/main/java/com/playlist/plitter/guest/repository/GuestUserRepository.java
+++ b/src/main/java/com/playlist/plitter/guest/repository/GuestUserRepository.java
@@ -3,8 +3,11 @@ package com.playlist.plitter.guest.repository;
 import com.playlist.plitter.guest.entity.GuestUserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GuestUserRepository extends JpaRepository<GuestUserEntity, Long> {
     boolean existsByGuestToken(String guestToken);
+    Optional<GuestUserEntity> findByGuestToken(String guestToken);
     boolean existsByRandomNickname(String randomNickname);
     boolean existsByRandomNicknameStartingWith(String prefix);
 }

--- a/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
@@ -39,7 +39,7 @@ public class PlaylistService {
 
         System.out.println("* 유저 아이디: " + userId);
 
-        UserEntity user = userRepository.findByKakaoId(String.valueOf(userId))
+        UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(AuthErrorCode.USER_NOT_FOUND));
 
         if (playlistRepository.existsByOwner(user)) {

--- a/src/main/java/com/playlist/plitter/playlist/presentation/PlaylistController.java
+++ b/src/main/java/com/playlist/plitter/playlist/presentation/PlaylistController.java
@@ -7,20 +7,12 @@ import com.playlist.plitter.playlist.application.dto.PlaylistCheckResponse;
 import com.playlist.plitter.playlist.application.dto.PlaylistCreateResponse;
 import com.playlist.plitter.playlist.application.dto.PlaylistResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-import com.playlist.plitter.playlist.domain.entity.PlaylistEntity;
-import com.playlist.plitter.playlist.domain.repository.PlaylistRepository;
-import com.playlist.plitter.playlist.exception.PlaylistErrorCode;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api")
@@ -30,11 +22,9 @@ public class PlaylistController {
     private final PlaylistService playlistService;
 
     @PostMapping("/playlists")
-    public ResponseDto<PlaylistCreateResponse> createPlaylist() {
-        Long userId = (Long) org.springframework.security.core.context.SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal();
+    public ResponseDto<PlaylistCreateResponse> createPlaylist(
+            @AuthenticationPrincipal Long userId
+    ) {
         PlaylistCreateResponse response = playlistService.savePlaylist(userId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
@@ -42,7 +32,7 @@ public class PlaylistController {
     @GetMapping("/playlists/check")
     public ResponseDto<PlaylistCheckResponse> checkPlaylist(
             @AuthenticationPrincipal Long userId
-        ) {
+    ) {
         PlaylistCheckResponse response = playlistService.checkPlaylist(userId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }

--- a/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
@@ -3,6 +3,8 @@ package com.playlist.plitter.recommendations.application;
 import com.playlist.plitter.auth.domain.entity.UserEntity;
 import com.playlist.plitter.auth.domain.repository.UserRepository;
 import com.playlist.plitter.auth.exception.AuthErrorCode;
+import com.playlist.plitter.guest.entity.GuestUserEntity;
+import com.playlist.plitter.guest.repository.GuestUserRepository;
 import com.playlist.plitter.playlist.domain.entity.PlaylistEntity;
 import com.playlist.plitter.playlist.domain.repository.PlaylistRepository;
 import com.playlist.plitter.global.exception.ApiException;
@@ -31,6 +33,7 @@ public class RecommendationsService {
     private final TrackRepository trackRepository;
     private final RecommendationsRepository recommendationsRepository;
     private final UserRepository userRepository;
+    private final GuestUserRepository guestUserRepository;
 
     @Transactional
     public RecommendationCreateResponse createRecommendation(
@@ -62,7 +65,10 @@ public class RecommendationsService {
             }
 
             guestToken = guestToken.trim();
-            randomNickname = randomNickname == null ? null : randomNickname.trim();
+            GuestUserEntity guest = guestUserRepository.findByGuestToken(guestToken)
+                    .orElseThrow(() -> new ApiException(RecommendationsErrorCode.GUEST_NOT_FOUND));
+            randomNickname = guest.getRandomNickname();
+
             long recommendationCount = recommendationsRepository.countByPlaylistAndGuestToken(playlist, guestToken);
             if (recommendationCount >= GUEST_RECOMMENDATION_LIMIT_PER_PLAYLIST) {
                 throw new ApiException(RecommendationsErrorCode.RECOMMENDATION_LIMIT_EXCEEDED);

--- a/src/main/java/com/playlist/plitter/recommendations/application/dto/RecommendationDetailResponse.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/dto/RecommendationDetailResponse.java
@@ -13,13 +13,13 @@ public record RecommendationDetailResponse(
         String artist,
         String albumCoverImageUrl,
         String previewUrl,
-        List<String> comments,
+        List<CommentResponse> comments,
         LocalDateTime createdAt
         // writer 추가 예정
 ) {
     public static RecommendationDetailResponse from(
             RecommendationsEntity recommendation,
-            List<String> comments
+            List<CommentResponse> comments
     ) {
         TrackEntity track = recommendation.getTrack();
 
@@ -32,9 +32,6 @@ public record RecommendationDetailResponse(
                 track.getPreviewUrl(),
                 comments,
                 recommendation.getCreatedAt()
-        );
-    }
-                comments
         );
     }
 

--- a/src/main/java/com/playlist/plitter/recommendations/exception/RecommendationsErrorCode.java
+++ b/src/main/java/com/playlist/plitter/recommendations/exception/RecommendationsErrorCode.java
@@ -7,7 +7,8 @@ public enum RecommendationsErrorCode implements ErrorCode {
     RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "추천된 곡을 찾을 수 없습니다.", "RECOMMENDATION_NOT_FOUND"),
     DUPLICATE_RECOMMENDATION(HttpStatus.CONFLICT, "동일한 추천이 존재합니다.", "DUPLICATE_RECOMMENDATION"),
     RECOMMENDATION_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "추천 허용 개수를 초과했습니다.", "RECOMMENDATION_LIMIT_EXCEEDED"),
-    GUEST_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "게스트 토큰이 필요합니다.", "GUEST_TOKEN_REQUIRED");
+    GUEST_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "게스트 토큰이 필요합니다.", "GUEST_TOKEN_REQUIRED"),
+    GUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "게스트를 찾을 수 없습니다.", "GUEST_NOT_FOUND");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/playlist/plitter/recommendations/presentation/RecommendationsController.java
+++ b/src/main/java/com/playlist/plitter/recommendations/presentation/RecommendationsController.java
@@ -34,12 +34,4 @@ public class RecommendationsController {
         RecommendationDetailResponse response = recommendationsService.getRecommendationDetail(recommendationId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
-
-    @GetMapping("/recommendations/{recommendationId}")
-    public ResponseDto<RecommendationDetailResponse> getRecommendationDetail(
-            @PathVariable Long recommendationId
-    ) {
-        RecommendationDetailResponse response = recommendationsService.getRecommendationDetail(recommendationId);
-        return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
-    }
 }


### PR DESCRIPTION
<!--
PR 제목에 커밋 타입 작성 X
-->

## 📌 관련 이슈
<!-- 연결된 이슈 -->
- closed: #이슈번호

## 📝 작업 내용
<!-- 수정/추가한 내용 -->
- 카카오 로그인 및 게스트 관련 인증 예외 경로를 추가
- 곡 검색 API를 인증 없이 접근할 수 있도록 수정
- 게스트 추천 등록이 가능하도록 추천 등록 API를 공개 접근으로 변경
- 플레이리스트 생성 시 JWT의 사용자 ID로 유저를 조회하도록 수정
- PlaylistController의 중복 import와 인증 사용자 ID 조회 방식을 정리했습니다.
- 게스트 추천 등록 시 요청 body의 `randomNickname`이 아니라, `guestToken`으로 조회한 게스트 세션의 랜덤 닉네임을 저장하도록 수정했습니다. (세훈님 개발 전 정리)
- 유효하지 않은 게스트 토큰에 대한 `GUEST_NOT_FOUND` 에러를 추가했습니다.

## 🔎 고민한 내용
<!-- 해당 PR중 고민한 내용 -->

## 💬 기타 참고 사항
<!-- 리뷰어에게 전달할 내용 -->
- 게스트 추천 등록 시 요청 body의 `randomNickname`이 아니라, `guestToken`으로 조회한 게스트 세션의 랜덤 닉네임을 저장하도록 수정했습니다.  게스트 로그인 할 때, 이미 랜덤닉네임이 생성되어 게스트세션 테이블에 저장되고있고, 특정 플레이리스트에 게스트로 추천이 1번만 가능하니까, 이거는 그대로 사용해도 될 것 같습니다.
-
- 카카오 로그인 사용자가 추천할 때, 익명 여부를 선택해서 랜덤닉네임이 생성되게하는 건 필요할 것 같아요! (->세훈님)
