### PR TITLE
Character 이미지 편집 OpenAI 실연동 및 S3 저장 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 }
 
 dependencies {
+    implementation platform('software.amazon.awssdk:bom:2.31.67')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
@@ -48,6 +49,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'se.michaelthelin.spotify:spotify-web-api-java:9.4.0'
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:url-connection-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/playlist/plitter/character/application/CharacterService.java
+++ b/src/main/java/com/playlist/plitter/character/application/CharacterService.java
@@ -98,12 +98,6 @@ public class CharacterService {
                 .orElseThrow(() -> new ApiException(CharacterErrorCode.PLAYLIST_NOT_FOUND));
     }
 
-    private CharacterEntity getLatestCharacterOrThrow(Long playlistId) {
-        getPlaylistOrThrow(playlistId);
-        return characterRepository.findTopByPlaylist_IdOrderByVersionDesc(playlistId)
-                .orElseThrow(() -> new ApiException(CharacterErrorCode.CHARACTER_NOT_FOUND));
-    }
-
     private CharacterEntity getLatestCreatedCharacterOrThrow(Long playlistId) {
         getPlaylistOrThrow(playlistId);
         return characterRepository.findTopByPlaylist_IdOrderByCreatedAtDescIdDesc(playlistId)

--- a/src/main/java/com/playlist/plitter/character/application/CharacterService.java
+++ b/src/main/java/com/playlist/plitter/character/application/CharacterService.java
@@ -79,12 +79,12 @@ public class CharacterService {
     }
 
     public CharacterDetailResponse getCharacter(Long playlistId) {
-        CharacterEntity character = getLatestCharacterOrThrow(playlistId);
+        CharacterEntity character = getLatestCreatedCharacterOrThrow(playlistId);
         return new CharacterDetailResponse(character.getId(), character.getImageUrl());
     }
 
     public CharacterDownloadUrlResponse getCharacterDownloadUrl(Long playlistId) {
-        CharacterEntity character = getLatestCharacterOrThrow(playlistId);
+        CharacterEntity character = getLatestCreatedCharacterOrThrow(playlistId);
         DownloadUrlResult downloadUrlResult = imageStorageClient.createDownloadUrl(character.getImageUrl());
         return new CharacterDownloadUrlResponse(
                 downloadUrlResult.downloadUrl(),
@@ -101,6 +101,12 @@ public class CharacterService {
     private CharacterEntity getLatestCharacterOrThrow(Long playlistId) {
         getPlaylistOrThrow(playlistId);
         return characterRepository.findTopByPlaylist_IdOrderByVersionDesc(playlistId)
+                .orElseThrow(() -> new ApiException(CharacterErrorCode.CHARACTER_NOT_FOUND));
+    }
+
+    private CharacterEntity getLatestCreatedCharacterOrThrow(Long playlistId) {
+        getPlaylistOrThrow(playlistId);
+        return characterRepository.findTopByPlaylist_IdOrderByCreatedAtDescIdDesc(playlistId)
                 .orElseThrow(() -> new ApiException(CharacterErrorCode.CHARACTER_NOT_FOUND));
     }
 

--- a/src/main/java/com/playlist/plitter/character/domain/repository/CharacterRepository.java
+++ b/src/main/java/com/playlist/plitter/character/domain/repository/CharacterRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface CharacterRepository extends JpaRepository<CharacterEntity, Long> {
     Optional<CharacterEntity> findTopByPlaylist_IdOrderByVersionDesc(Long playlistId);
+    Optional<CharacterEntity> findTopByPlaylist_IdOrderByCreatedAtDescIdDesc(Long playlistId);
 }

--- a/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
+++ b/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
@@ -12,7 +12,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -49,6 +52,8 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
 
     public S3ImageStorageClient(
             @Value("${aws.region:${AWS_REGION:ap-northeast-2}}") String awsRegion,
+            @Value("${aws.access-key-id:${AWS_ACCESS_KEY_ID:}}") String accessKeyId,
+            @Value("${aws.secret-access-key:${AWS_SECRET_ACCESS_KEY:}}") String secretAccessKey,
             @Value("${character.storage.s3.bucket}") String bucket,
             @Value("${character.storage.s3.key-prefix:characters}") String keyPrefix,
             @Value("${character.storage.s3.public-base-url:}") String publicBaseUrl,
@@ -60,7 +65,7 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
         this.downloadExpiryMinutes = downloadExpiryMinutes > 0 ? downloadExpiryMinutes : 30;
 
         Region region = Region.of(awsRegion);
-        DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
+        AwsCredentialsProvider credentialsProvider = resolveCredentialsProvider(accessKeyId, secretAccessKey);
         this.s3Client = S3Client.builder()
                 .region(region)
                 .credentialsProvider(credentialsProvider)
@@ -229,6 +234,15 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
         }
         String trimmed = value.trim();
         return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+    }
+
+    private AwsCredentialsProvider resolveCredentialsProvider(String accessKeyId, String secretAccessKey) {
+        if (StringUtils.hasText(accessKeyId) && StringUtils.hasText(secretAccessKey)) {
+            return StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKeyId.trim(), secretAccessKey.trim())
+            );
+        }
+        return DefaultCredentialsProvider.create();
     }
 
     private record StoredImageInput(

--- a/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
+++ b/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -38,6 +40,7 @@ import java.util.regex.Pattern;
 @Component
 public class S3ImageStorageClient implements ImageStorageClient, DisposableBean {
 
+    private static final Logger log = LoggerFactory.getLogger(S3ImageStorageClient.class);
     private static final Pattern DATA_URI_PATTERN =
             Pattern.compile("^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", Pattern.DOTALL);
     private static final String DEFAULT_CONTENT_TYPE = MediaType.IMAGE_PNG_VALUE;
@@ -94,6 +97,7 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
         } catch (ApiException e) {
             throw e;
         } catch (Exception e) {
+            log.error("S3 image upload failed: playlistId={}, source={}", playlistId, sourceImageUrl, e);
             throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
         }
     }
@@ -119,6 +123,7 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
         } catch (ApiException e) {
             throw e;
         } catch (Exception e) {
+            log.error("S3 download URL creation failed: imageUrl={}", imageUrl, e);
             throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
         }
     }

--- a/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
+++ b/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
@@ -1,0 +1,240 @@
+package com.playlist.plitter.character.infrastructure.s3;
+
+import com.playlist.plitter.character.application.port.ImageStorageClient;
+import com.playlist.plitter.character.application.port.dto.DownloadUrlResult;
+import com.playlist.plitter.character.exception.CharacterErrorCode;
+import com.playlist.plitter.global.exception.ApiException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Primary
+@Component
+public class S3ImageStorageClient implements ImageStorageClient, DisposableBean {
+
+    private static final Pattern DATA_URI_PATTERN =
+            Pattern.compile("^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", Pattern.DOTALL);
+    private static final String DEFAULT_CONTENT_TYPE = MediaType.IMAGE_PNG_VALUE;
+
+    private final String bucket;
+    private final String keyPrefix;
+    private final String publicBaseUrl;
+    private final int downloadExpiryMinutes;
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final RestClient restClient;
+
+    public S3ImageStorageClient(
+            @Value("${aws.region:${AWS_REGION:ap-northeast-2}}") String awsRegion,
+            @Value("${character.storage.s3.bucket}") String bucket,
+            @Value("${character.storage.s3.key-prefix:characters}") String keyPrefix,
+            @Value("${character.storage.s3.public-base-url:}") String publicBaseUrl,
+            @Value("${character.storage.s3.download-expiry-minutes:30}") int downloadExpiryMinutes
+    ) {
+        this.bucket = bucket;
+        this.keyPrefix = normalizeKeyPrefix(keyPrefix);
+        this.publicBaseUrl = trimTrailingSlash(publicBaseUrl);
+        this.downloadExpiryMinutes = downloadExpiryMinutes > 0 ? downloadExpiryMinutes : 30;
+
+        Region region = Region.of(awsRegion);
+        DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
+        this.s3Client = S3Client.builder()
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .build();
+        this.s3Presigner = S3Presigner.builder()
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .build();
+        this.restClient = RestClient.builder().build();
+    }
+
+    @Override
+    public String storeCharacterImage(Long playlistId, String sourceImageUrl) {
+        try {
+            StoredImageInput input = resolveSourceImage(sourceImageUrl);
+            String objectKey = createObjectKey(playlistId, input.extension());
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey)
+                    .contentType(input.contentType())
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(input.bytes()));
+            return buildPublicImageUrl(objectKey);
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
+        }
+    }
+
+    @Override
+    public DownloadUrlResult createDownloadUrl(String imageUrl) {
+        try {
+            String objectKey = extractObjectKey(imageUrl);
+
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey)
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(downloadExpiryMinutes))
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(downloadExpiryMinutes);
+            return new DownloadUrlResult(presignedRequest.url().toString(), expiresAt);
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        s3Presigner.close();
+        s3Client.close();
+    }
+
+    private StoredImageInput resolveSourceImage(String sourceImageUrl) {
+        if (!StringUtils.hasText(sourceImageUrl)) {
+            throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
+        }
+        if (sourceImageUrl.startsWith("data:image/")) {
+            return parseDataUri(sourceImageUrl);
+        }
+        return downloadRemoteImage(sourceImageUrl);
+    }
+
+    private StoredImageInput parseDataUri(String dataUri) {
+        Matcher matcher = DATA_URI_PATTERN.matcher(dataUri);
+        if (!matcher.matches()) {
+            throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
+        }
+
+        String contentType = matcher.group(1);
+        String base64Data = matcher.group(2);
+        byte[] bytes = Base64.getDecoder().decode(base64Data);
+        String extension = resolveExtension(contentType);
+        return new StoredImageInput(bytes, contentType, extension);
+    }
+
+    private StoredImageInput downloadRemoteImage(String sourceImageUrl) {
+        ResponseEntity<byte[]> response = restClient.get()
+                .uri(URI.create(sourceImageUrl))
+                .retrieve()
+                .toEntity(byte[].class);
+
+        byte[] bytes = response.getBody();
+        if (bytes == null || bytes.length == 0) {
+            throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
+        }
+
+        String contentType = response.getHeaders().getContentType() != null
+                ? response.getHeaders().getContentType().toString()
+                : DEFAULT_CONTENT_TYPE;
+        String extension = resolveExtension(contentType);
+        return new StoredImageInput(bytes, contentType, extension);
+    }
+
+    private String createObjectKey(Long playlistId, String extension) {
+        String randomName = UUID.randomUUID().toString().replace("-", "");
+        return keyPrefix + "/" + playlistId + "/" + randomName + "." + extension;
+    }
+
+    private String buildPublicImageUrl(String objectKey) {
+        if (StringUtils.hasText(publicBaseUrl)) {
+            return publicBaseUrl + "/" + objectKey;
+        }
+        return s3Client.utilities()
+                .getUrl(GetUrlRequest.builder().bucket(bucket).key(objectKey).build())
+                .toExternalForm();
+    }
+
+    private String extractObjectKey(String imageUrl) {
+        if (!StringUtils.hasText(imageUrl)) {
+            throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
+        }
+        if (StringUtils.hasText(publicBaseUrl) && imageUrl.startsWith(publicBaseUrl + "/")) {
+            return imageUrl.substring((publicBaseUrl + "/").length());
+        }
+
+        URI uri = URI.create(imageUrl);
+        String path = uri.getPath();
+        if (!StringUtils.hasText(path)) {
+            throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
+        }
+
+        String normalizedPath = path.startsWith("/") ? path.substring(1) : path;
+        if (normalizedPath.startsWith(bucket + "/")) {
+            return normalizedPath.substring(bucket.length() + 1);
+        }
+        return normalizedPath;
+    }
+
+    private String resolveExtension(String contentType) {
+        String lowerContentType = contentType.toLowerCase();
+        if (lowerContentType.contains("image/png")) {
+            return "png";
+        }
+        if (lowerContentType.contains("image/jpeg") || lowerContentType.contains("image/jpg")) {
+            return "jpg";
+        }
+        if (lowerContentType.contains("image/webp")) {
+            return "webp";
+        }
+        return "png";
+    }
+
+    private String normalizeKeyPrefix(String rawPrefix) {
+        if (!StringUtils.hasText(rawPrefix)) {
+            return "characters";
+        }
+        String trimmed = rawPrefix.trim();
+        String withoutLeading = trimmed.startsWith("/") ? trimmed.substring(1) : trimmed;
+        return withoutLeading.endsWith("/") ? withoutLeading.substring(0, withoutLeading.length() - 1) : withoutLeading;
+    }
+
+    private String trimTrailingSlash(String value) {
+        if (!StringUtils.hasText(value)) {
+            return value;
+        }
+        String trimmed = value.trim();
+        return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+    }
+
+    private record StoredImageInput(
+            byte[] bytes,
+            String contentType,
+            String extension
+    ) {
+    }
+}

--- a/src/main/java/com/playlist/plitter/character/infrastructure/stub/StubImageStorageClient.java
+++ b/src/main/java/com/playlist/plitter/character/infrastructure/stub/StubImageStorageClient.java
@@ -2,10 +2,12 @@ package com.playlist.plitter.character.infrastructure.stub;
 
 import com.playlist.plitter.character.application.port.ImageStorageClient;
 import com.playlist.plitter.character.application.port.dto.DownloadUrlResult;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 
+@Profile("character-stub")
 @Component
 public class StubImageStorageClient implements ImageStorageClient {
 


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #47
- closed: #49

## 📝 작업 내용
- `OpenAiCharacterImageEditClient`를 통해 Character 이미지 편집을 OpenAI 실연동으로 전환
- 이미지 편집 요청 시 multipart 기반 `images/edits` 호출 및 응답(`b64_json`/`url`) 파싱 처리
- base 캐릭터 이미지를 OpenAI 입력 형식으로 변환(클래스패스/파일/원격 URL 로드 지원)
- `S3ImageStorageClient` 구현으로 생성 이미지를 S3에 업로드하고 저장 URL 반환
- 다운로드용 presigned URL 생성 API 연동
- `S3ImageStorageClient`에서 `aws.access-key-id`/`aws.secret-access-key` 기반 자격증명 주입 지원(미설정 시 default provider fallback)
- 캐릭터 조회/다운로드 URL API가 최신 생성 캐릭터 기준으로 동작하도록 정리
- S3 연동 실패 시 원인 추적을 위한 예외 로그 보강
- `feature_summary_json`의 `jsonb` 매핑 처리 보강(`@JdbcTypeCode(SqlTypes.JSON)`)

## 🔎 고민한 내용
- OpenAI 이미지 편집 단계는 기존 “텍스트 분석 AI + 이미지 AI” 2단계 대신, 규칙 기반 `CharacterEditSpec` + 이미지 AI 1회 호출 구조를 유지
- 스텁을 완전히 제거하지 않고, 실연동 경로를 기본으로 사용하면서 필요 시 스텁 전환 가능한 구조를 유지
- 최신 캐릭터 기준 정의를 버전이 아닌 생성 시점 기준으로 맞춰 API 응답 일관성을 확보

## 💬 기타 참고 사항
- 캐릭터 생성/조회/다운로드 URL까지 실호출 검증 완료
- 현재 캐릭터 생성 가능 여부 판단은 `playlist.recommendation_count`를 기준으로 동작하므로, 추천곡 수 집계 동기화 이슈는 별도 정리가 필요합니다.