### PR TITLE
추천 작성자 닉네임 처리 방식 수정

### DIFF
--- a/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
@@ -5,6 +5,7 @@ import com.playlist.plitter.auth.domain.repository.UserRepository;
 import com.playlist.plitter.auth.exception.AuthErrorCode;
 import com.playlist.plitter.guest.entity.GuestUserEntity;
 import com.playlist.plitter.guest.repository.GuestUserRepository;
+import com.playlist.plitter.guest.service.NicknameGenerator;
 import com.playlist.plitter.playlist.domain.entity.PlaylistEntity;
 import com.playlist.plitter.playlist.domain.repository.PlaylistRepository;
 import com.playlist.plitter.global.exception.ApiException;
@@ -46,7 +47,8 @@ public class RecommendationsService {
 
         UserEntity recommenderUser = null;
         String guestToken = request.guestToken();
-        String randomNickname = request.randomNickname();
+        String randomNickname = null;
+        boolean isAnonymous = request.isAnonymous();
 
         if (recommenderUserId != null) {
             recommenderUser = userRepository.findById(recommenderUserId)
@@ -58,7 +60,9 @@ public class RecommendationsService {
             }
 
             guestToken = null;
-            randomNickname = null;
+            if (isAnonymous) {
+                randomNickname = NicknameGenerator.generate(guestUserRepository);
+            }
         } else {
             if (guestToken == null || guestToken.isBlank()) {
                 throw new ApiException(RecommendationsErrorCode.GUEST_TOKEN_REQUIRED);
@@ -68,6 +72,7 @@ public class RecommendationsService {
             GuestUserEntity guest = guestUserRepository.findByGuestToken(guestToken)
                     .orElseThrow(() -> new ApiException(RecommendationsErrorCode.GUEST_NOT_FOUND));
             randomNickname = guest.getRandomNickname();
+            isAnonymous = true;
 
             long recommendationCount = recommendationsRepository.countByPlaylistAndGuestToken(playlist, guestToken);
             if (recommendationCount >= GUEST_RECOMMENDATION_LIMIT_PER_PLAYLIST) {
@@ -99,7 +104,7 @@ public class RecommendationsService {
                 .recommenderUser(recommenderUser)
                 .guestToken(guestToken)
                 .randomNickname(randomNickname)
-                .isAnonymous(request.isAnonymous())
+                .isAnonymous(isAnonymous)
                 .comment(request.comment())
                 .build();
 

--- a/src/main/java/com/playlist/plitter/recommendations/application/dto/RecommendationDetailResponse.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/dto/RecommendationDetailResponse.java
@@ -40,9 +40,9 @@ public record RecommendationDetailResponse(
             String comment
     ) {
         public static CommentResponse from(RecommendationsEntity recommendation) {
-            String recommenderName = recommendation.getRecommenderUser() != null
-                    ? recommendation.getRecommenderUser().getNickname()
-                    : recommendation.getRandomNickname();
+            String recommenderName = recommendation.isAnonymous() || recommendation.getRecommenderUser() == null
+                    ? recommendation.getRandomNickname()
+                    : recommendation.getRecommenderUser().getNickname();
 
             return new CommentResponse(recommenderName, recommendation.getComment());
         }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 연결된 이슈 -->
- closed: #46 

## 📝 작업 내용
- 게스트 추천 등록 시 요청값과 관계없이 isAnonymous가 true로 저장되도록 수정했습니다.
- 게스트 추천 등록 시 guest_sessions.random_nickname을 조회해 추천의 randomNickname으로 저장하도록 수정했습니다.
- 카카오 로그인 사용자가 익명 추천을 등록하면 랜덤 닉네임을 생성해 저장하도록 수정했습니다.
- 카카오 로그인 사용자가 비익명 추천을 등록하면 users.nickname이 표시되도록 코멘트 조회 로직을 수정했습니다.
- 코멘트 조회 시 익명 여부와 게스트 여부에 따라 닉네임이 결정되도록 수정했습니다.

## 🔎 고민한 내용
- 카카오 사용자의 익명 추천은 사용자 정보는 유지하되, 화면 표시 이름만 랜덤 닉네임을 사용

## 💬 기타 참고 사항
- 로컬에서 Swagger로 게스트, 카카오 비익명, 카카오 익명 추천 등록/조회 흐름을 확인했습니다.
- 테스트용으로 추가했던 로컬 dev API는 확인 후 제거했습니다.
