### PR TITLE
노래 재생 API

### DIFF
--- a/src/main/java/com/playlist/plitter/track/application/TrackService.java
+++ b/src/main/java/com/playlist/plitter/track/application/TrackService.java
@@ -3,6 +3,7 @@ package com.playlist.plitter.track.application;
 import com.playlist.plitter.global.exception.ApiException;
 import com.playlist.plitter.track.application.dto.TrackPlayResponse;
 import com.playlist.plitter.track.application.dto.TrackSearchResponse;
+import com.playlist.plitter.track.domain.repository.TrackRepository;
 import com.playlist.plitter.track.exception.TrackErrorCode;
 import com.playlist.plitter.track.infrastructure.spotify.SpotifyTrackClient;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.List;
 public class TrackService {
 
     private final SpotifyTrackClient spotifyTrackClient;
+    private final TrackRepository trackRepository;
 
     public List<TrackSearchResponse> searchTracks(String keyword, Integer limit) {
         if (keyword == null || keyword.isBlank()) {

--- a/src/main/java/com/playlist/plitter/track/application/TrackService.java
+++ b/src/main/java/com/playlist/plitter/track/application/TrackService.java
@@ -1,6 +1,7 @@
 package com.playlist.plitter.track.application;
 
 import com.playlist.plitter.global.exception.ApiException;
+import com.playlist.plitter.track.application.dto.TrackPlayResponse;
 import com.playlist.plitter.track.application.dto.TrackSearchResponse;
 import com.playlist.plitter.track.exception.TrackErrorCode;
 import com.playlist.plitter.track.infrastructure.spotify.SpotifyTrackClient;
@@ -28,5 +29,17 @@ public class TrackService {
             throw new ApiException(TrackErrorCode.TRACK_SEARCH_FAILED);
 
         }
+    }
+
+    public TrackPlayResponse getTrackEmbedUrl(String spotifyTrackId) {
+        if (spotifyTrackId == null || spotifyTrackId.isBlank()) {
+            throw new ApiException(TrackErrorCode.INVALID_REQUEST);
+        }
+
+        trackRepository.findBySpotifyTrackId(spotifyTrackId)
+                .orElseThrow(() -> new ApiException(TrackErrorCode.TRACK_NOT_FOUND));
+
+        String embedUrl = "https://open.spotify.com/embed/track/" + spotifyTrackId;
+        return new TrackPlayResponse(spotifyTrackId, embedUrl);
     }
 }

--- a/src/main/java/com/playlist/plitter/track/application/dto/TrackPlayResponse.java
+++ b/src/main/java/com/playlist/plitter/track/application/dto/TrackPlayResponse.java
@@ -1,0 +1,7 @@
+package com.playlist.plitter.track.application.dto;
+
+public record TrackPlayResponse(
+        String spotifyTrackId,
+        String embedUrl
+) {
+}

--- a/src/main/java/com/playlist/plitter/track/exception/TrackErrorCode.java
+++ b/src/main/java/com/playlist/plitter/track/exception/TrackErrorCode.java
@@ -7,7 +7,8 @@ public enum TrackErrorCode implements ErrorCode {
 
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "검색어는 필수입니다.", "INVALID_REQUEST"),
     SPOTIFY_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Spotify 인증에 실패했습니다.", "SPOTIFY_UNAUTHORIZED"),
-    TRACK_SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "노래 검색 중 오류가 발생했습니다.", "INTERNAL_SERVER_ERROR");
+    TRACK_SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "노래 검색 중 오류가 발생했습니다.", "INTERNAL_SERVER_ERROR"),
+    TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "트랙을 찾을 수 없습니다.", "TRACK_NOT_FOUND");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/playlist/plitter/track/presentation/TrackController.java
+++ b/src/main/java/com/playlist/plitter/track/presentation/TrackController.java
@@ -3,12 +3,10 @@ package com.playlist.plitter.track.presentation;
 import com.playlist.plitter.global.dto.ResponseDto;
 import com.playlist.plitter.global.dto.SuccessMessage;
 import com.playlist.plitter.track.application.TrackService;
+import com.playlist.plitter.track.application.dto.TrackPlayResponse;
 import com.playlist.plitter.track.application.dto.TrackSearchResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,6 +23,14 @@ public class TrackController {
             @RequestParam(defaultValue = "10") Integer limit
     ) {
         List<TrackSearchResponse> result = trackService.searchTracks(keyword, limit);
+        return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, result);
+    }
+
+    @GetMapping("/{spotifyTrackId}/play")
+    public ResponseDto<TrackPlayResponse> getTrackEmbedUrl(
+            @PathVariable String spotifyTrackId
+    ) {
+        TrackPlayResponse result = trackService.getTrackEmbedUrl(spotifyTrackId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, result);
     }
 }


### PR DESCRIPTION
<!--
PR 제목에 커밋 타입 작성 X
--> 

## 📌 관련 이슈
<!-- 연결된 이슈 -->
- closed: #56 

## 📝 작업 내용
<!-- 수정/추가한 내용 -->
- TrackPlayResponse DTO 추가
- TrackErrorCode에 TRACK_NOT_FOUND 에러코드 추가
- TrackService에 getTrackEmbedUrl() 메서드 추가
- TrackController에 GET /api/tracks/{spotifyTrackId}/play 엔드포인트 추가

## 🔎 고민한 내용
<!-- 해당 PR중 고민한 내용 -->
재생 시 새 창이 열리지 않고 사이트 내에서 바로 재생 가능한데 
여기서 현재 플레이어 진행 방식과 조금 차이가 있어서 프론트 분이랑 상의 예정입니다. 
현재 방식은 노래 커버, 음원 모두 따로 저장을 해서 가져오는 방식인데 이 방식은 현재 모든 플랫폼에서 미리 듣기 API를 제공하지 않아서 
oEmbed 방식으로 스포티파이 플레이어 자체를 가져오는 방식이라 현재 앨범 커버 부분에 oEmbed URL을 iframe으로 넣고
커스텀 된 재생 버튼이랑 연결을 지을 예정입니다. 이 연결을 짓는과정에서 조금 힘들거 같은데 구현 방식이 나와있는게 따로 있을까요?

## 💬 기타 참고 사항
<!-- 리뷰어에게 전달할 내용 -->
