### PR TITLE
Character 생성 완료 화면 메타데이터 응답 추가

### DIFF
--- a/src/main/java/com/playlist/plitter/character/application/CharacterResultMetadataGenerator.java
+++ b/src/main/java/com/playlist/plitter/character/application/CharacterResultMetadataGenerator.java
@@ -1,0 +1,100 @@
+package com.playlist.plitter.character.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.playlist.plitter.character.application.dto.CharacterResultMetadata;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Component
+public class CharacterResultMetadataGenerator {
+
+    private static final double HIGH_ENERGY_THRESHOLD = 0.65;
+    private static final double HIGH_VALENCE_THRESHOLD = 0.60;
+    private static final double LOW_VALENCE_THRESHOLD = 0.40;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public CharacterResultMetadata generate(String featureSummaryJson) {
+        try {
+            JsonNode root = objectMapper.readTree(featureSummaryJson);
+            double avgEnergy = root.path("avgEnergy").asDouble(0.0);
+            double avgValence = root.path("avgValence").asDouble(0.0);
+            String primaryGenre = root.path("primaryGenre").asText("balanced");
+            String styleTone = createStyleTone(avgEnergy, avgValence);
+
+            String characterName = buildCharacterName(primaryGenre, styleTone);
+            List<String> tags = List.of(
+                    "#" + styleToneTag(styleTone),
+                    "#" + energyTag(avgEnergy),
+                    "#" + valenceTag(avgValence)
+            );
+            return new CharacterResultMetadata(characterName, tags);
+        } catch (Exception e) {
+            return new CharacterResultMetadata("리듬 스타", List.of("#조화로운", "#감각적인", "#분위기있는"));
+        }
+    }
+
+    private String createStyleTone(double avgEnergy, double avgValence) {
+        if (avgEnergy >= HIGH_ENERGY_THRESHOLD) {
+            return avgValence >= HIGH_VALENCE_THRESHOLD ? "energetic-bright" : "energetic-intense";
+        }
+        if (avgValence <= LOW_VALENCE_THRESHOLD) {
+            return "calm-deep";
+        }
+        return "balanced";
+    }
+
+    private String buildCharacterName(String primaryGenre, String styleTone) {
+        String genreLabel = toGenreLabel(primaryGenre);
+        String toneLabel = switch (styleTone) {
+            case "energetic-bright" -> "스텝";
+            case "energetic-intense" -> "비트";
+            case "calm-deep" -> "무드";
+            default -> "리듬";
+        };
+        return genreLabel + " " + toneLabel + " 스타";
+    }
+
+    private String toGenreLabel(String genre) {
+        if (!StringUtils.hasText(genre)) {
+            return "플리";
+        }
+        String normalized = genre.trim().toLowerCase();
+        return switch (normalized) {
+            case "k-pop", "kpop" -> "케이팝";
+            case "hip-hop", "hiphop", "rap" -> "힙합";
+            case "rock" -> "록";
+            case "ballad" -> "발라드";
+            case "r&b", "rnb" -> "알앤비";
+            case "edm", "dance" -> "댄스";
+            case "jazz" -> "재즈";
+            default -> "플리";
+        };
+    }
+
+    private String styleToneTag(String styleTone) {
+        return switch (styleTone) {
+            case "energetic-bright" -> "밝은";
+            case "energetic-intense" -> "강렬한";
+            case "calm-deep" -> "잔잔한";
+            default -> "조화로운";
+        };
+    }
+
+    private String energyTag(double avgEnergy) {
+        return avgEnergy >= HIGH_ENERGY_THRESHOLD ? "열정적인" : "차분한";
+    }
+
+    private String valenceTag(double avgValence) {
+        if (avgValence >= HIGH_VALENCE_THRESHOLD) {
+            return "쾌활한";
+        }
+        if (avgValence <= LOW_VALENCE_THRESHOLD) {
+            return "감성적인";
+        }
+        return "균형잡힌";
+    }
+}

--- a/src/main/java/com/playlist/plitter/character/application/CharacterService.java
+++ b/src/main/java/com/playlist/plitter/character/application/CharacterService.java
@@ -7,6 +7,7 @@ import com.playlist.plitter.character.application.port.BaseCharacterClient;
 import com.playlist.plitter.character.application.port.CharacterImageEditClient;
 import com.playlist.plitter.character.application.port.ImageStorageClient;
 import com.playlist.plitter.character.application.port.MusicFeatureClient;
+import com.playlist.plitter.character.application.dto.CharacterResultMetadata;
 import com.playlist.plitter.character.application.port.dto.CharacterEditSpec;
 import com.playlist.plitter.character.application.port.dto.CharacterImageEditRequest;
 import com.playlist.plitter.character.application.port.dto.DownloadUrlResult;
@@ -40,6 +41,7 @@ public class CharacterService {
     private final PlaylistRepository playlistRepository;
     private final MusicFeatureClient musicFeatureClient;
     private final CharacterEditSpecGenerator characterEditSpecGenerator;
+    private final CharacterResultMetadataGenerator characterResultMetadataGenerator;
     private final BaseCharacterClient baseCharacterClient;
     private final CharacterImageEditClient characterImageEditClient;
     private final ImageStorageClient imageStorageClient;
@@ -70,26 +72,42 @@ public class CharacterService {
         String editedCharacterImageUrl = editCharacterImage(editSpec);
         String storedCharacterImageUrl = storeCharacterImage(playlistId, editedCharacterImageUrl);
 
-        return saveCharacterWithTransaction(
+        CharacterEntity savedCharacter = saveCharacterWithTransaction(
                 playlistId,
                 storedCharacterImageUrl,
                 editSpec.promptText(),
                 featureSummaryJson
         );
+        CharacterResultMetadata metadata = generateResultMetadata(savedCharacter.getFeatureSummaryJson());
+        return new CharacterCreateResponse(
+                savedCharacter.getId(),
+                savedCharacter.getImageUrl(),
+                metadata.characterName(),
+                metadata.tags()
+        );
     }
 
     public CharacterDetailResponse getCharacter(Long playlistId) {
         CharacterEntity character = getLatestCreatedCharacterOrThrow(playlistId);
-        return new CharacterDetailResponse(character.getId(), character.getImageUrl());
+        CharacterResultMetadata metadata = generateResultMetadata(character.getFeatureSummaryJson());
+        return new CharacterDetailResponse(
+                character.getId(),
+                character.getImageUrl(),
+                metadata.characterName(),
+                metadata.tags()
+        );
     }
 
     public CharacterDownloadUrlResponse getCharacterDownloadUrl(Long playlistId) {
         CharacterEntity character = getLatestCreatedCharacterOrThrow(playlistId);
         DownloadUrlResult downloadUrlResult = imageStorageClient.createDownloadUrl(character.getImageUrl());
+        CharacterResultMetadata metadata = generateResultMetadata(character.getFeatureSummaryJson());
         return new CharacterDownloadUrlResponse(
                 downloadUrlResult.downloadUrl(),
                 character.getImageUrl(),
-                downloadUrlResult.expiresAt()
+                downloadUrlResult.expiresAt(),
+                metadata.characterName(),
+                metadata.tags()
         );
     }
 
@@ -158,7 +176,7 @@ public class CharacterService {
         return value;
     }
 
-    private CharacterCreateResponse saveCharacterWithTransaction(
+    private CharacterEntity saveCharacterWithTransaction(
             Long playlistId,
             String storedCharacterImageUrl,
             String promptText,
@@ -167,7 +185,7 @@ public class CharacterService {
         for (int attempt = 1; attempt <= SAVE_RETRY_COUNT; attempt++) {
             try {
                 TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-                CharacterCreateResponse response = transactionTemplate.execute(status -> {
+                CharacterEntity response = transactionTemplate.execute(status -> {
                     PlaylistEntity managedPlaylist = getPlaylistOrThrow(playlistId);
                     int nextVersion = characterRepository.findTopByPlaylist_IdOrderByVersionDesc(playlistId)
                             .map(character -> character.getVersion() + 1)
@@ -182,7 +200,7 @@ public class CharacterService {
                                     featureSummaryJson
                             )
                     );
-                    return new CharacterCreateResponse(savedCharacter.getId(), savedCharacter.getImageUrl());
+                    return savedCharacter;
                 });
                 return Objects.requireNonNull(response);
             } catch (DataIntegrityViolationException e) {
@@ -192,5 +210,9 @@ public class CharacterService {
             }
         }
         throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
+    }
+
+    private CharacterResultMetadata generateResultMetadata(String featureSummaryJson) {
+        return characterResultMetadataGenerator.generate(featureSummaryJson);
     }
 }

--- a/src/main/java/com/playlist/plitter/character/application/dto/CharacterResultMetadata.java
+++ b/src/main/java/com/playlist/plitter/character/application/dto/CharacterResultMetadata.java
@@ -1,0 +1,9 @@
+package com.playlist.plitter.character.application.dto;
+
+import java.util.List;
+
+public record CharacterResultMetadata(
+        String characterName,
+        List<String> tags
+) {
+}

--- a/src/main/java/com/playlist/plitter/character/presentation/dto/response/CharacterCreateResponse.java
+++ b/src/main/java/com/playlist/plitter/character/presentation/dto/response/CharacterCreateResponse.java
@@ -1,7 +1,11 @@
 package com.playlist.plitter.character.presentation.dto.response;
 
+import java.util.List;
+
 public record CharacterCreateResponse(
         Long characterId,
-        String imageUrl
+        String imageUrl,
+        String characterName,
+        List<String> tags
 ) {
 }

--- a/src/main/java/com/playlist/plitter/character/presentation/dto/response/CharacterDetailResponse.java
+++ b/src/main/java/com/playlist/plitter/character/presentation/dto/response/CharacterDetailResponse.java
@@ -1,7 +1,11 @@
 package com.playlist.plitter.character.presentation.dto.response;
 
+import java.util.List;
+
 public record CharacterDetailResponse(
         Long characterId,
-        String imageUrl
+        String imageUrl,
+        String characterName,
+        List<String> tags
 ) {
 }

--- a/src/main/java/com/playlist/plitter/character/presentation/dto/response/CharacterDownloadUrlResponse.java
+++ b/src/main/java/com/playlist/plitter/character/presentation/dto/response/CharacterDownloadUrlResponse.java
@@ -1,10 +1,13 @@
 package com.playlist.plitter.character.presentation.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CharacterDownloadUrlResponse(
         String downloadUrl,
         String imageUrl,
-        LocalDateTime expiresAt
+        LocalDateTime expiresAt,
+        String characterName,
+        List<String> tags
 ) {
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #63

## 📝 작업 내용
- Character 완료 화면에서 바로 사용할 수 있도록 응답에 `characterName`, `tags` 필드를 추가했습니다.
- `create/get/download-url` 응답 DTO를 확장해 이미지 URL과 함께 메타데이터를 반환하도록 정리했습니다.
- `featureSummaryJson` 기반으로 이름/태그를 생성하는 `CharacterResultMetadataGenerator`를 추가하고 `CharacterService`에 매핑했습니다.
- 기존 필드(`characterId`, `imageUrl`, `downloadUrl`, `expiresAt`)는 유지해 호환성을 지켰습니다.

## 🔎 고민한 내용
- 이름/태그는 DB 컬럼을 늘리지 않고 저장된 `featureSummaryJson`을 단일 소스로 활용해 생성하도록 설계했습니다.
- 생성 실패 시 화면 공백을 피하기 위해 기본 fallback 이름/태그를 제공하도록 처리했습니다.
- 완료 화면과 다운로드 화면의 데이터 소스가 달라지지 않도록 서비스 레벨에서 동일 생성 로직을 재사용했습니다.

## 💬 기타 참고 사항
- 컴파일 확인: `./gradlew compileJava` (성공)
- 추후 프론트 요구가 바뀌면 태그 구성 규칙만 생성기에서 교체하면 됩니다.
