### PR TITLE
Character API 플레이리스트 소유권 검증 추가

### DIFF
--- a/src/main/java/com/playlist/plitter/character/application/CharacterService.java
+++ b/src/main/java/com/playlist/plitter/character/application/CharacterService.java
@@ -47,8 +47,8 @@ public class CharacterService {
     private final ImageStorageClient imageStorageClient;
     private final PlatformTransactionManager transactionManager;
 
-    public CharacterAvailabilityResponse getAvailability(Long playlistId) {
-        PlaylistEntity playlist = getPlaylistOrThrow(playlistId);
+    public CharacterAvailabilityResponse getAvailability(Long playlistId, Long requesterUserId) {
+        PlaylistEntity playlist = getOwnedPlaylistOrThrow(playlistId, requesterUserId);
         int currentCount = playlist.getRecommendationCount();
         int missingCount = Math.max(REQUIRED_RECOMMENDATION_COUNT - currentCount, 0);
 
@@ -61,8 +61,8 @@ public class CharacterService {
     }
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    public CharacterCreateResponse createCharacter(Long playlistId) {
-        PlaylistEntity playlist = getPlaylistOrThrow(playlistId);
+    public CharacterCreateResponse createCharacter(Long playlistId, Long requesterUserId) {
+        PlaylistEntity playlist = getOwnedPlaylistOrThrow(playlistId, requesterUserId);
         if (!isCreatable(playlist)) {
             throw new ApiException(CharacterErrorCode.CHARACTER_NOT_AVAILABLE);
         }
@@ -74,6 +74,7 @@ public class CharacterService {
 
         CharacterEntity savedCharacter = saveCharacterWithTransaction(
                 playlistId,
+                requesterUserId,
                 storedCharacterImageUrl,
                 editSpec.promptText(),
                 featureSummaryJson
@@ -87,8 +88,8 @@ public class CharacterService {
         );
     }
 
-    public CharacterDetailResponse getCharacter(Long playlistId) {
-        CharacterEntity character = getLatestCreatedCharacterOrThrow(playlistId);
+    public CharacterDetailResponse getCharacter(Long playlistId, Long requesterUserId) {
+        CharacterEntity character = getLatestCreatedCharacterOrThrow(playlistId, requesterUserId);
         CharacterResultMetadata metadata = generateResultMetadata(character.getFeatureSummaryJson());
         return new CharacterDetailResponse(
                 character.getId(),
@@ -98,8 +99,8 @@ public class CharacterService {
         );
     }
 
-    public CharacterDownloadUrlResponse getCharacterDownloadUrl(Long playlistId) {
-        CharacterEntity character = getLatestCreatedCharacterOrThrow(playlistId);
+    public CharacterDownloadUrlResponse getCharacterDownloadUrl(Long playlistId, Long requesterUserId) {
+        CharacterEntity character = getLatestCreatedCharacterOrThrow(playlistId, requesterUserId);
         DownloadUrlResult downloadUrlResult = imageStorageClient.createDownloadUrl(character.getImageUrl());
         CharacterResultMetadata metadata = generateResultMetadata(character.getFeatureSummaryJson());
         return new CharacterDownloadUrlResponse(
@@ -111,13 +112,13 @@ public class CharacterService {
         );
     }
 
-    private PlaylistEntity getPlaylistOrThrow(Long playlistId) {
-        return playlistRepository.findById(playlistId)
+    private PlaylistEntity getOwnedPlaylistOrThrow(Long playlistId, Long requesterUserId) {
+        return playlistRepository.findByIdAndOwner_Id(playlistId, requesterUserId)
                 .orElseThrow(() -> new ApiException(CharacterErrorCode.PLAYLIST_NOT_FOUND));
     }
 
-    private CharacterEntity getLatestCreatedCharacterOrThrow(Long playlistId) {
-        getPlaylistOrThrow(playlistId);
+    private CharacterEntity getLatestCreatedCharacterOrThrow(Long playlistId, Long requesterUserId) {
+        getOwnedPlaylistOrThrow(playlistId, requesterUserId);
         return characterRepository.findTopByPlaylist_IdOrderByCreatedAtDescIdDesc(playlistId)
                 .orElseThrow(() -> new ApiException(CharacterErrorCode.CHARACTER_NOT_FOUND));
     }
@@ -178,6 +179,7 @@ public class CharacterService {
 
     private CharacterEntity saveCharacterWithTransaction(
             Long playlistId,
+            Long requesterUserId,
             String storedCharacterImageUrl,
             String promptText,
             String featureSummaryJson
@@ -186,7 +188,7 @@ public class CharacterService {
             try {
                 TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
                 CharacterEntity response = transactionTemplate.execute(status -> {
-                    PlaylistEntity managedPlaylist = getPlaylistOrThrow(playlistId);
+                    PlaylistEntity managedPlaylist = getOwnedPlaylistOrThrow(playlistId, requesterUserId);
                     int nextVersion = characterRepository.findTopByPlaylist_IdOrderByVersionDesc(playlistId)
                             .map(character -> character.getVersion() + 1)
                             .orElse(1);

--- a/src/main/java/com/playlist/plitter/character/presentation/CharacterController.java
+++ b/src/main/java/com/playlist/plitter/character/presentation/CharacterController.java
@@ -8,6 +8,7 @@ import com.playlist.plitter.character.presentation.dto.response.CharacterDownloa
 import com.playlist.plitter.global.dto.ResponseDto;
 import com.playlist.plitter.global.dto.SuccessMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,33 +20,37 @@ public class CharacterController {
 
     @GetMapping("/availability")
     public ResponseDto<CharacterAvailabilityResponse> getCharacterAvailability(
-            @PathVariable Long playlistId
+            @PathVariable Long playlistId,
+            @AuthenticationPrincipal Long requesterUserId
     ) {
-        CharacterAvailabilityResponse response = characterService.getAvailability(playlistId);
+        CharacterAvailabilityResponse response = characterService.getAvailability(playlistId, requesterUserId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
 
     @PostMapping
     public ResponseDto<CharacterCreateResponse> createCharacter(
-            @PathVariable Long playlistId
+            @PathVariable Long playlistId,
+            @AuthenticationPrincipal Long requesterUserId
     ) {
-        CharacterCreateResponse response = characterService.createCharacter(playlistId);
+        CharacterCreateResponse response = characterService.createCharacter(playlistId, requesterUserId);
         return ResponseDto.ofSuccess(SuccessMessage.CREATE_SUCCESS, response);
     }
 
     @GetMapping
     public ResponseDto<CharacterDetailResponse> getCharacter(
-            @PathVariable Long playlistId
+            @PathVariable Long playlistId,
+            @AuthenticationPrincipal Long requesterUserId
     ) {
-        CharacterDetailResponse response = characterService.getCharacter(playlistId);
+        CharacterDetailResponse response = characterService.getCharacter(playlistId, requesterUserId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
 
     @GetMapping("/download-url")
     public ResponseDto<CharacterDownloadUrlResponse> getCharacterDownloadUrl(
-            @PathVariable Long playlistId
+            @PathVariable Long playlistId,
+            @AuthenticationPrincipal Long requesterUserId
     ) {
-        CharacterDownloadUrlResponse response = characterService.getCharacterDownloadUrl(playlistId);
+        CharacterDownloadUrlResponse response = characterService.getCharacterDownloadUrl(playlistId, requesterUserId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
 }

--- a/src/main/java/com/playlist/plitter/playlist/domain/repository/PlaylistRepository.java
+++ b/src/main/java/com/playlist/plitter/playlist/domain/repository/PlaylistRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public interface PlaylistRepository extends JpaRepository<PlaylistEntity, Long> {
     boolean existsByOwner(UserEntity owner);
     Optional<PlaylistEntity> findByOwnerId(Long ownerId);
+    Optional<PlaylistEntity> findByIdAndOwner_Id(Long playlistId, Long ownerId);
 
     @Modifying
     @Query("update PlaylistEntity p set p.recommendationCount = p.recommendationCount + 1 where p = :playlist")

--- a/src/test/java/com/playlist/plitter/character/application/CharacterDownloadUrlRealFlowTest.java
+++ b/src/test/java/com/playlist/plitter/character/application/CharacterDownloadUrlRealFlowTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import jakarta.persistence.EntityManager;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -20,12 +21,16 @@ class CharacterDownloadUrlRealFlowTest {
     @Autowired
     private CharacterService characterService;
 
+    @Autowired
+    private EntityManager entityManager;
+
     @Test
     void getDownloadUrl_realFlow() throws Exception {
         String rawPlaylistId = System.getenv().getOrDefault("CHARACTER_REAL_FLOW_PLAYLIST_ID", "2");
         Long playlistId = Long.parseLong(rawPlaylistId);
+        Long requesterUserId = findOwnerUserId(playlistId);
 
-        CharacterDownloadUrlResponse response = characterService.getCharacterDownloadUrl(playlistId);
+        CharacterDownloadUrlResponse response = characterService.getCharacterDownloadUrl(playlistId, requesterUserId);
         assertThat(response.downloadUrl()).isNotBlank();
         assertThat(response.expiresAt()).isNotNull();
 
@@ -41,5 +46,14 @@ class CharacterDownloadUrlRealFlowTest {
                 + " status=" + httpResponse.statusCode()
                 + " expiresAt=" + response.expiresAt()
                 + " downloadUrl=" + response.downloadUrl());
+    }
+
+    private Long findOwnerUserId(Long playlistId) {
+        return entityManager.createQuery(
+                        "select p.owner.id from PlaylistEntity p where p.id = :playlistId",
+                        Long.class
+                )
+                .setParameter("playlistId", playlistId)
+                .getSingleResult();
     }
 }

--- a/src/test/java/com/playlist/plitter/character/application/CharacterGenerationRealFlowTest.java
+++ b/src/test/java/com/playlist/plitter/character/application/CharacterGenerationRealFlowTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import jakarta.persistence.EntityManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,17 +16,30 @@ class CharacterGenerationRealFlowTest {
     @Autowired
     private CharacterService characterService;
 
+    @Autowired
+    private EntityManager entityManager;
+
     @Test
     void createCharacter_realFlow() {
         String rawPlaylistId = System.getenv().getOrDefault("CHARACTER_REAL_FLOW_PLAYLIST_ID", "2");
         Long playlistId = Long.parseLong(rawPlaylistId);
+        Long requesterUserId = findOwnerUserId(playlistId);
 
-        CharacterCreateResponse response = characterService.createCharacter(playlistId);
+        CharacterCreateResponse response = characterService.createCharacter(playlistId, requesterUserId);
 
         assertThat(response.characterId()).isNotNull();
         assertThat(response.imageUrl()).isNotBlank();
         System.out.println("CHARACTER_REAL_FLOW_RESULT playlistId=" + playlistId
                 + " characterId=" + response.characterId()
                 + " imageUrl=" + response.imageUrl());
+    }
+
+    private Long findOwnerUserId(Long playlistId) {
+        return entityManager.createQuery(
+                        "select p.owner.id from PlaylistEntity p where p.id = :playlistId",
+                        Long.class
+                )
+                .setParameter("playlistId", playlistId)
+                .getSingleResult();
     }
 }

--- a/src/test/java/com/playlist/plitter/character/application/CharacterGenerationSmokeTest.java
+++ b/src/test/java/com/playlist/plitter/character/application/CharacterGenerationSmokeTest.java
@@ -36,8 +36,9 @@ class CharacterGenerationSmokeTest {
     @Test
     void createCharacter_generatesAndPersistsCharacter() {
         Long playlistId = findCreatablePlaylistId();
+        Long requesterUserId = findOwnerUserId(playlistId);
 
-        CharacterCreateResponse response = characterService.createCharacter(playlistId);
+        CharacterCreateResponse response = characterService.createCharacter(playlistId, requesterUserId);
         Long characterId = response.characterId();
         String expectedStoredImageUrl = "https://mock.local/stored/" + playlistId + ".png";
 
@@ -68,6 +69,15 @@ class CharacterGenerationSmokeTest {
                 .stream()
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("캐릭터 생성 가능한 플레이리스트가 없습니다."));
+    }
+
+    private Long findOwnerUserId(Long playlistId) {
+        return entityManager.createQuery(
+                        "select p.owner.id from PlaylistEntity p where p.id = :playlistId",
+                        Long.class
+                )
+                .setParameter("playlistId", playlistId)
+                .getSingleResult();
     }
 
     @TestConfiguration


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #67

## 📝 작업 내용
- Character API 전 경로(`availability/create/get/download-url`)에 `@AuthenticationPrincipal` 사용자 식별자를 전달하도록 변경했습니다.
- `CharacterService`의 주요 메서드 시그니처를 `(playlistId, requesterUserId)` 기반으로 변경했습니다.
- 플레이리스트 조회를 `playlistId` 단독 조회에서 `playlistId + ownerUserId` 소유권 검증 조회로 변경했습니다.
- 소유하지 않은 플레이리스트 접근 시 `PLAYLIST_NOT_FOUND`를 반환하도록 통일했습니다.

## 🔎 고민한 내용
- IDOR 차단 관점에서 "존재함 + 권한없음"을 구분해서 노출하지 않도록 존재 은닉 정책(`PLAYLIST_NOT_FOUND`)을 유지했습니다.
- 캐릭터 관련 엔드포인트 일부만 막지 않고 전체 경로에 동일한 검증을 적용해 우회 경로를 제거했습니다.

## 💬 기타 참고 사항
- 컴파일 검증: `./gradlew compileJava` 성공
- 수동 검증:
  - owner(userId=2): `/api/playlists/2/character/availability` 성공
  - non-owner(userId=1): availability/get/download-url 모두 `PLAYLIST_NOT_FOUND`
