### PR TITLE
Spotify 검색 API limit 초과(20) 요청 시 500 에러 수정

### DIFF
--- a/src/main/java/com/playlist/plitter/track/infrastructure/spotify/SpotifyTrackClient.java
+++ b/src/main/java/com/playlist/plitter/track/infrastructure/spotify/SpotifyTrackClient.java
@@ -18,6 +18,7 @@ import se.michaelthelin.spotify.requests.data.search.SearchItemRequest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -42,7 +43,9 @@ public class SpotifyTrackClient {
                     .build();
 
             SearchResult searchResult = searchItemRequest.execute();
-            Track[] tracks = searchResult.getTracks().getItems();
+            Track[] tracks = (searchResult != null && searchResult.getTracks() != null && searchResult.getTracks().getItems() != null)
+                    ? searchResult.getTracks().getItems()
+                    : new Track[0];
 
             List<TrackSearchResponse> result = new ArrayList<>();
 
@@ -52,12 +55,16 @@ public class SpotifyTrackClient {
                         : "";
 
                 String albumImageUrl = "";
-                Image[] images = track.getAlbum().getImages();
+                Image[] images = (track.getAlbum() != null) ? track.getAlbum().getImages() : null;
                 if (images != null && images.length > 0) {
                     albumImageUrl = images[0].getUrl();
                 }
 
-                String spotifyUrl = track.getExternalUrls().getExternalUrls().get("spotify");
+                String spotifyUrl = "";
+                if (track.getExternalUrls() != null) {
+                    Map<String, String> externalUrls = track.getExternalUrls().getExternalUrls();
+                    spotifyUrl = externalUrls != null ? externalUrls.getOrDefault("spotify", "") : "";
+                }
 
                 result.add(new TrackSearchResponse(
                         track.getId(),

--- a/src/main/java/com/playlist/plitter/track/infrastructure/spotify/SpotifyTrackClient.java
+++ b/src/main/java/com/playlist/plitter/track/infrastructure/spotify/SpotifyTrackClient.java
@@ -22,6 +22,9 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class SpotifyTrackClient {
+    private static final int SPOTIFY_SEARCH_MIN_LIMIT = 1;
+    private static final int SPOTIFY_SEARCH_MAX_LIMIT = 10;
+    private static final int SPOTIFY_SEARCH_DEFAULT_LIMIT = 5;
 
     @Value("${spotify.client-id}")
     private String clientId;
@@ -32,9 +35,10 @@ public class SpotifyTrackClient {
     public List<TrackSearchResponse> searchTracks(String keyword, Integer limit) {
         try {
             SpotifyApi spotifyApi = createSpotifyApi();
+            int normalizedLimit = normalizeLimit(limit);
 
             SearchItemRequest searchItemRequest = spotifyApi.searchItem(keyword, ModelObjectType.TRACK.getType())
-                    .limit(limit)
+                    .limit(normalizedLimit)
                     .build();
 
             SearchResult searchResult = searchItemRequest.execute();
@@ -71,6 +75,16 @@ public class SpotifyTrackClient {
         } catch (Exception e) {
             throw new ApiException(TrackErrorCode.TRACK_SEARCH_FAILED);
         }
+    }
+
+    private int normalizeLimit(Integer limit) {
+        if (limit == null) {
+            return SPOTIFY_SEARCH_DEFAULT_LIMIT;
+        }
+        if (limit < SPOTIFY_SEARCH_MIN_LIMIT) {
+            return SPOTIFY_SEARCH_MIN_LIMIT;
+        }
+        return Math.min(limit, SPOTIFY_SEARCH_MAX_LIMIT);
     }
 
     private SpotifyApi createSpotifyApi() throws Exception {


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #72

## 📝 작업 내용
- Spotify 트랙 검색 `limit` 입력값을 1~10 범위로 보정하고, 미입력 시 기본값(5) 사용
- Spotify 검색 응답 매핑 시 `tracks`, `album`, `externalUrls` null-safe 처리 추가
- `limit=20` 요청에서도 검색 API가 500이 아닌 정상 응답을 반환하도록 수정

## 🔎 고민한 내용
- 프론트 요청값(`limit=20`)을 즉시 바꾸는 대신, 백엔드에서 외부 API 제약을 흡수하도록 처리해 기존 클라이언트 호환성을 유지했습니다.
- 예외를 광범위하게 감싸는 구조에서 런타임 NPE 가능성을 줄이기 위해 응답 매핑 경로를 방어적으로 변경했습니다.

## 💬 기타 참고 사항
- local 검증: `./gradlew compileJava` 성공
- 서버 검증: `GET /api/tracks/search?keyword=zico&limit=20` 및 `keyword=%EC%A7%80%EC%BD%94&limit=20` 모두 HTTP 200 확인
