### PR TITLE
게스트 로그인에서도 친구 플리 커버 조회 가능한 공개 API 추가

### DIFF
--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/kakao/**").permitAll()
                         .requestMatchers("/api/auth/guest").permitAll()
                         .requestMatchers("/auth/logout").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/playlists/*/public").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/playlists/*/recommendations").permitAll()
                         .requestMatchers("/api/tracks/search").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
@@ -1,29 +1,25 @@
 package com.playlist.plitter.playlist.application;
 
+import com.playlist.plitter.auth.domain.entity.UserEntity;
+import com.playlist.plitter.auth.domain.repository.UserRepository;
+import com.playlist.plitter.auth.exception.AuthErrorCode;
 import com.playlist.plitter.playlist.application.dto.PlaylistCheckResponse;
 import com.playlist.plitter.playlist.application.dto.PlaylistCreateResponse;
+import com.playlist.plitter.playlist.application.dto.PlaylistPublicResponse;
 import com.playlist.plitter.playlist.application.dto.PlaylistResponse;
 import com.playlist.plitter.playlist.domain.entity.PlaylistEntity;
 import com.playlist.plitter.playlist.domain.repository.PlaylistRepository;
-import com.playlist.plitter.auth.domain.entity.UserEntity;
-import com.playlist.plitter.auth.domain.repository.UserRepository;
 import com.playlist.plitter.global.exception.ApiException;
-import com.playlist.plitter.playlist.exception.PlaylistErrorCode;
 import com.playlist.plitter.recommendations.application.dto.RecommendationResponse;
+import com.playlist.plitter.recommendations.domain.entity.RecommendationsEntity;
 import com.playlist.plitter.recommendations.domain.repository.RecommendationsRepository;
 import com.playlist.plitter.track.domain.entity.TrackEntity;
+import com.playlist.plitter.playlist.exception.PlaylistErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
-import com.playlist.plitter.auth.exception.AuthErrorCode;
-import com.playlist.plitter.global.exception.ApiException;
-import com.playlist.plitter.playlist.exception.PlaylistErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.Optional;
 import java.util.UUID;
 
@@ -100,6 +96,26 @@ public class PlaylistService {
         }
 
         return new PlaylistCheckResponse(false, null);
+    }
+
+    @Transactional(readOnly = true)
+    public PlaylistPublicResponse getPlaylistPublic(Long playlistId) {
+        PlaylistEntity playlist = playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new ApiException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+        String latestCoverImageUrl = recommendationsRepository.findTopByPlaylistOrderByCreatedAtDescIdDesc(playlist)
+                .map(RecommendationsEntity::getTrack)
+                .map(TrackEntity::getAlbumCoverUrl)
+                .orElse(null);
+
+        int recommendationCount = playlist.getRecommendationCount();
+        return new PlaylistPublicResponse(
+                playlist.getId(),
+                playlist.getShortId(),
+                recommendationCount,
+                recommendationCount >= 10,
+                latestCoverImageUrl
+        );
     }
 
 }

--- a/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistPublicResponse.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistPublicResponse.java
@@ -1,0 +1,10 @@
+package com.playlist.plitter.playlist.application.dto;
+
+public record PlaylistPublicResponse(
+        Long playlistId,
+        String shortId,
+        Integer recommendationCount,
+        Boolean canCreateCharacter,
+        String latestCoverImageUrl
+) {
+}

--- a/src/main/java/com/playlist/plitter/playlist/presentation/PlaylistController.java
+++ b/src/main/java/com/playlist/plitter/playlist/presentation/PlaylistController.java
@@ -5,6 +5,7 @@ import com.playlist.plitter.global.dto.SuccessMessage;
 import com.playlist.plitter.playlist.application.PlaylistService;
 import com.playlist.plitter.playlist.application.dto.PlaylistCheckResponse;
 import com.playlist.plitter.playlist.application.dto.PlaylistCreateResponse;
+import com.playlist.plitter.playlist.application.dto.PlaylistPublicResponse;
 import com.playlist.plitter.playlist.application.dto.PlaylistResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,6 +43,14 @@ public class PlaylistController {
             @PathVariable Long playlistId
     ) {
         PlaylistResponse response = playlistService.getPlaylist(playlistId);
+        return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
+    }
+
+    @GetMapping("/playlists/{playlistId}/public")
+    public ResponseDto<PlaylistPublicResponse> getPlaylistPublic(
+            @PathVariable Long playlistId
+    ) {
+        PlaylistPublicResponse response = playlistService.getPlaylistPublic(playlistId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
 

--- a/src/main/java/com/playlist/plitter/recommendations/domain/repository/RecommendationsRepository.java
+++ b/src/main/java/com/playlist/plitter/recommendations/domain/repository/RecommendationsRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RecommendationsRepository extends JpaRepository<RecommendationsEntity, Long> {
@@ -32,4 +33,6 @@ public interface RecommendationsRepository extends JpaRepository<Recommendations
             PlaylistEntity playlist,
             String guestToken
     );
+
+    Optional<RecommendationsEntity> findTopByPlaylistOrderByCreatedAtDescIdDesc(PlaylistEntity playlist);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #74

## 📝 작업 내용
- `GET /api/playlists/{playlistId}/public` 공개 전용 API 추가
- 공개 응답 DTO `PlaylistPublicResponse` 추가
- PlaylistService에 공개 조회 로직 추가
  - playlist 기본 정보 조회
  - 최신 추천곡 기준 커버 이미지 1장 추출
- RecommendationsRepository에 최신 추천 1건 조회 메서드 추가
- SecurityConfig에 공개 API 경로 permitAll 추가

## 🔎 고민한 내용
- 기존 `GET /api/playlists/{playlistId}`를 공개로 전환하면 인증 경계가 흐려질 수 있어, 별도 `/public` 엔드포인트로 분리해 최소 정보만 노출하도록 설계했습니다.

## 💬 기타 참고 사항
- `./gradlew test -q` 통과
