### PR TITLE
공유 플레이리스트 public API 응답 확장 (ownerNickname/recommendations)

### DIFF
--- a/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
@@ -63,19 +63,7 @@ public class PlaylistService {
         PlaylistEntity playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new ApiException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
-        List<RecommendationResponse> recommendations = recommendationsRepository.findAllByPlaylist(playlist)
-                .stream()
-                .map(recommendation -> {
-                    TrackEntity track = recommendation.getTrack();
-                    return new RecommendationResponse(
-                            track.getSpotifyTrackId(),
-                            track.getTitle(),
-                            track.getArtistName(),
-                            track.getAlbumCoverUrl(),
-                            track.getPreviewUrl()
-                    );
-                })
-                .toList();
+        List<RecommendationResponse> recommendations = toRecommendationResponses(playlist);
 
         return new PlaylistResponse(
                 playlist.getId(),
@@ -103,6 +91,7 @@ public class PlaylistService {
         PlaylistEntity playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new ApiException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
+        List<RecommendationResponse> recommendations = toRecommendationResponses(playlist);
         String latestCoverImageUrl = recommendationsRepository.findTopByPlaylistOrderByCreatedAtDescIdDesc(playlist)
                 .map(RecommendationsEntity::getTrack)
                 .map(TrackEntity::getAlbumCoverUrl)
@@ -114,8 +103,26 @@ public class PlaylistService {
                 playlist.getShortId(),
                 recommendationCount,
                 recommendationCount >= 10,
+                playlist.getOwner().getNickname(),
+                recommendations,
                 latestCoverImageUrl
         );
+    }
+
+    private List<RecommendationResponse> toRecommendationResponses(PlaylistEntity playlist) {
+        return recommendationsRepository.findAllByPlaylist(playlist)
+                .stream()
+                .map(recommendation -> {
+                    TrackEntity track = recommendation.getTrack();
+                    return new RecommendationResponse(
+                            track.getSpotifyTrackId(),
+                            track.getTitle(),
+                            track.getArtistName(),
+                            track.getAlbumCoverUrl(),
+                            track.getPreviewUrl()
+                    );
+                })
+                .toList();
     }
 
 }

--- a/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistPublicResponse.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistPublicResponse.java
@@ -1,10 +1,16 @@
 package com.playlist.plitter.playlist.application.dto;
 
+import com.playlist.plitter.recommendations.application.dto.RecommendationResponse;
+
+import java.util.List;
+
 public record PlaylistPublicResponse(
         Long playlistId,
         String shortId,
         Integer recommendationCount,
         Boolean canCreateCharacter,
+        String ownerNickname,
+        List<RecommendationResponse> recommendations,
         String latestCoverImageUrl
 ) {
 }


### PR DESCRIPTION
## 📌 관련 이슈
- refs: #74

## 📝 작업 내용
- `GET /api/playlists/{playlistId}/public` 응답 확장
- `ownerNickname` 필드 추가
- `recommendations: RecommendationResponse[]` 필드 추가
- public API에서도 전체 추천곡 목록을 내려주도록 서비스 로직 보강
- 기존 `latestCoverImageUrl` 필드는 하위호환을 위해 유지

## 🔎 고민한 내용
- 공유 페이지 요구사항(비로그인에서도 모든 커버/곡 목록 표시)을 맞추기 위해 기존 public API 확장 방식을 선택했습니다.

## 💬 기타 참고 사항
- `./gradlew test -q` 통과
