### PR TITLE
플레이리스트 추천 곡 수 동기화 기준 정합성 수정

### DIFF
--- a/src/main/java/com/playlist/plitter/character/application/CharacterService.java
+++ b/src/main/java/com/playlist/plitter/character/application/CharacterService.java
@@ -18,6 +18,7 @@ import com.playlist.plitter.character.presentation.dto.response.CharacterDownloa
 import com.playlist.plitter.global.exception.ApiException;
 import com.playlist.plitter.playlist.domain.entity.PlaylistEntity;
 import com.playlist.plitter.playlist.domain.repository.PlaylistRepository;
+import com.playlist.plitter.recommendations.domain.repository.RecommendationsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -46,14 +47,15 @@ public class CharacterService {
     private final CharacterImageEditClient characterImageEditClient;
     private final ImageStorageClient imageStorageClient;
     private final PlatformTransactionManager transactionManager;
+    private final RecommendationsRepository recommendationsRepository;
 
     public CharacterAvailabilityResponse getAvailability(Long playlistId, Long requesterUserId) {
         PlaylistEntity playlist = getOwnedPlaylistOrThrow(playlistId, requesterUserId);
-        int currentCount = playlist.getRecommendationCount();
+        int currentCount = getActualRecommendationCount(playlist);
         int missingCount = Math.max(REQUIRED_RECOMMENDATION_COUNT - currentCount, 0);
 
         return new CharacterAvailabilityResponse(
-                isCreatable(playlist),
+                isCreatable(currentCount),
                 REQUIRED_RECOMMENDATION_COUNT,
                 currentCount,
                 missingCount
@@ -63,7 +65,8 @@ public class CharacterService {
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public CharacterCreateResponse createCharacter(Long playlistId, Long requesterUserId) {
         PlaylistEntity playlist = getOwnedPlaylistOrThrow(playlistId, requesterUserId);
-        if (!isCreatable(playlist)) {
+        int currentCount = getActualRecommendationCount(playlist);
+        if (!isCreatable(currentCount)) {
             throw new ApiException(CharacterErrorCode.CHARACTER_NOT_AVAILABLE);
         }
 
@@ -123,8 +126,12 @@ public class CharacterService {
                 .orElseThrow(() -> new ApiException(CharacterErrorCode.CHARACTER_NOT_FOUND));
     }
 
-    private boolean isCreatable(PlaylistEntity playlist) {
-        return playlist.getRecommendationCount() >= REQUIRED_RECOMMENDATION_COUNT;
+    private int getActualRecommendationCount(PlaylistEntity playlist) {
+        return (int) recommendationsRepository.countByPlaylist(playlist);
+    }
+
+    private boolean isCreatable(int recommendationCount) {
+        return recommendationCount >= REQUIRED_RECOMMENDATION_COUNT;
     }
 
     private String collectFeatureSummary(Long playlistId) {

--- a/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
@@ -64,11 +64,12 @@ public class PlaylistService {
                 .orElseThrow(() -> new ApiException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         List<RecommendationResponse> recommendations = toRecommendationResponses(playlist);
+        int recommendationCount = recommendations.size();
 
         return new PlaylistResponse(
                 playlist.getId(),
-                playlist.getRecommendationCount(),
-                playlist.getRecommendationCount() >= 10,
+                recommendationCount,
+                recommendationCount >= 10,
                 recommendations
         );
     }
@@ -97,7 +98,7 @@ public class PlaylistService {
                 .map(TrackEntity::getAlbumCoverUrl)
                 .orElse(null);
 
-        int recommendationCount = playlist.getRecommendationCount();
+        int recommendationCount = recommendations.size();
         return new PlaylistPublicResponse(
                 playlist.getId(),
                 playlist.getShortId(),

--- a/src/main/java/com/playlist/plitter/recommendations/domain/repository/RecommendationsRepository.java
+++ b/src/main/java/com/playlist/plitter/recommendations/domain/repository/RecommendationsRepository.java
@@ -34,5 +34,7 @@ public interface RecommendationsRepository extends JpaRepository<Recommendations
             String guestToken
     );
 
+    long countByPlaylist(PlaylistEntity playlist);
+
     Optional<RecommendationsEntity> findTopByPlaylistOrderByCreatedAtDescIdDesc(PlaylistEntity playlist);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #77

## 📝 작업 내용
- `GET /api/playlists/{playlistId}` 응답의 `recommendationCount`를 실제 추천 목록 크기 기준으로 계산
- `GET /api/playlists/{playlistId}/public` 응답의 `recommendationCount`를 실제 추천 목록 크기 기준으로 계산
- `RecommendationsRepository`에 `countByPlaylist` 메서드 추가
- Character 가용성/생성 가능 여부 계산에서 `playlist.recommendationCount` 대신 실제 추천 레코드 수 사용

## 🔎 고민한 내용
- 캐시성 컬럼(`playlist.recommendation_count`)과 실제 추천 레코드 수가 어긋날 수 있어, 사용자에게 노출되는 응답/비즈니스 판단은 실제 데이터 기준으로 통일했습니다.

## 💬 기타 참고 사항
- `./gradlew test -q` 통과
