### PR TITLE
게스트 재진입 코멘트 복원을 위한 public 추천 응답/조회 API 확장

### DIFF
--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/guest").permitAll()
                         .requestMatchers("/auth/logout").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/playlists/*/public").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/playlists/recommendations/*/public").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/playlists/*/recommendations").permitAll()
                         .requestMatchers("/api/tracks/search").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
@@ -19,9 +19,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -111,16 +114,23 @@ public class PlaylistService {
     }
 
     private List<RecommendationResponse> toRecommendationResponses(PlaylistEntity playlist) {
-        return recommendationsRepository.findAllByPlaylist(playlist)
+        List<RecommendationsEntity> recommendations = recommendationsRepository.findAllByPlaylist(playlist);
+        Map<String, Long> commentCountBySpotifyId = recommendations.stream()
+                .map(recommendation -> recommendation.getTrack().getSpotifyTrackId())
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        return recommendations
                 .stream()
                 .map(recommendation -> {
                     TrackEntity track = recommendation.getTrack();
                     return new RecommendationResponse(
+                            recommendation.getId(),
                             track.getSpotifyTrackId(),
                             track.getTitle(),
                             track.getArtistName(),
                             track.getAlbumCoverUrl(),
-                            track.getPreviewUrl()
+                            track.getPreviewUrl(),
+                            commentCountBySpotifyId.getOrDefault(track.getSpotifyTrackId(), 0L).intValue()
                     );
                 })
                 .toList();

--- a/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
@@ -136,4 +136,9 @@ public class RecommendationsService {
 
         return RecommendationDetailResponse.from(recommendation, comments);
     }
+
+    @Transactional(readOnly = true)
+    public RecommendationDetailResponse getRecommendationPublicDetail(Long recommendationId) {
+        return getRecommendationDetail(recommendationId);
+    }
 }

--- a/src/main/java/com/playlist/plitter/recommendations/application/dto/RecommendationResponse.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/dto/RecommendationResponse.java
@@ -1,10 +1,12 @@
 package com.playlist.plitter.recommendations.application.dto;
 
 public record RecommendationResponse(
+        Long recommendationId,
         String spotifyId,
         String title,
         String artistName,
         String albumCoverImageUrl,
-        String previewUrl
+        String previewUrl,
+        Integer commentCount
 ) {
 }

--- a/src/main/java/com/playlist/plitter/recommendations/presentation/RecommendationsController.java
+++ b/src/main/java/com/playlist/plitter/recommendations/presentation/RecommendationsController.java
@@ -34,4 +34,12 @@ public class RecommendationsController {
         RecommendationDetailResponse response = recommendationsService.getRecommendationDetail(recommendationId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
+
+    @GetMapping("/recommendations/{recommendationId}/public")
+    public ResponseDto<RecommendationDetailResponse> getRecommendationPublicDetail(
+            @PathVariable Long recommendationId
+    ) {
+        RecommendationDetailResponse response = recommendationsService.getRecommendationPublicDetail(recommendationId);
+        return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #79

## 📝 작업 내용
- `RecommendationResponse`에 `recommendationId`, `commentCount` 필드 추가
- playlist 추천 목록 변환 시 트랙(spotifyId) 기준 코멘트 수를 집계해 `commentCount` 반영
- 비로그인 코멘트 조회용 `GET /api/playlists/recommendations/{recommendationId}/public` 추가
- Security 설정에 공개 상세 조회 경로 permitAll 추가

## 🔎 고민한 내용
- 게스트 재진입 시 코멘트 복원은 "추천 식별자 + 비로그인 조회 경로"가 함께 있어야 안정적으로 동작하므로, 응답 확장과 public 상세 API를 동시에 반영했습니다.

## 💬 기타 참고 사항
- `./gradlew test -q` 통과
