### PR TITLE
게스트도 곡 플레이어 embed URL을 조회할 수 있도록 공개 접근 허용

### DIFF
--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/playlists/recommendations/*/public").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/playlists/*/recommendations").permitAll()
                         .requestMatchers("/api/tracks/search").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/tracks/*/play").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 작업 내용
- `GET /api/tracks/{spotifyTrackId}/play` 경로를 공개 접근으로 열어 게스트/비로그인 사용자도 플레이어 embed URL을 조회할 수 있도록 수정
- 기존 `track search`와 동일하게 플레이어 조회도 공유 추천 플로우에서 인증 없이 사용할 수 있도록 보안 정책 정리
- 로그인 사용자 요청 경로에는 영향 없이 게스트 추천 플로우 차단만 해소

## 테스트
- ./gradlew build

Closes #84
