### PR TITLE
캐릭터 이미지 투명 배경 생성 안정화 재적용

### DIFF
--- a/src/main/java/com/playlist/plitter/character/application/CharacterEditSpecGenerator.java
+++ b/src/main/java/com/playlist/plitter/character/application/CharacterEditSpecGenerator.java
@@ -71,7 +71,7 @@ public class CharacterEditSpecGenerator {
                     - Do not polish, smooth, vectorize, thicken, or professionalize the line art.
                     - Preserve small irregularities and naive hand-drawn imperfections.
                     - No color, no shading, no gradients, no 3D rendering, and no paper texture.
-                    - Transparent background.
+                    - Use a fully transparent background with alpha, not a plain white background.
                     - Avoid solid filled areas; use sparse simple hatching only if necessary.
                     Style direction:
                     %s

--- a/src/main/java/com/playlist/plitter/character/infrastructure/openai/OpenAiCharacterImageEditClient.java
+++ b/src/main/java/com/playlist/plitter/character/infrastructure/openai/OpenAiCharacterImageEditClient.java
@@ -43,6 +43,7 @@ public class OpenAiCharacterImageEditClient implements CharacterImageEditClient 
     private static final Logger log = LoggerFactory.getLogger(OpenAiCharacterImageEditClient.class);
     private static final String IMAGE_EDIT_PATH = "/v1/images/edits";
     private static final String DEFAULT_IMAGE_MEDIA_TYPE = "image/png";
+    private static final String TRANSPARENT_BACKGROUND = "transparent";
     private static final String SHAPE_PRESERVATION_RULES =
             "Strict character constraints: keep the same doodle star mascot family and base silhouette logic. " +
                     "Preserve the rough hand-drawn line quality and naive doodle character feel from the input image. " +
@@ -100,30 +101,8 @@ public class OpenAiCharacterImageEditClient implements CharacterImageEditClient 
                 throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
             }
 
-            MultiValueMap<String, Object> formData = new LinkedMultiValueMap<>();
-            formData.add("model", openAiModel);
-            formData.add("prompt", buildPrompt(request.editSpec().promptText(), inputImages.size() > 1));
-            formData.add("size", openAiSize);
-            formData.add("quality", openAiQuality);
-            formData.add("n", "1");
-            formData.add("output_format", "png");
-            for (SourceImage inputImage : inputImages) {
-                HttpHeaders imageHeaders = new HttpHeaders();
-                imageHeaders.setContentType(inputImage.mediaType());
-                HttpEntity<ByteArrayResource> imagePart = new HttpEntity<>(
-                        new NamedByteArrayResource(inputImage.bytes(), inputImage.filename()),
-                        imageHeaders
-                );
-                formData.add("image[]", imagePart);
-            }
-
-            ImageEditResponse response = openAiRestClient.post()
-                    .uri(IMAGE_EDIT_PATH)
-                    .contentType(MediaType.MULTIPART_FORM_DATA)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + openAiApiKey)
-                    .body(formData)
-                    .retrieve()
-                    .body(ImageEditResponse.class);
+            String prompt = buildPrompt(request.editSpec().promptText(), inputImages.size() > 1);
+            ImageEditResponse response = requestImageEdit(prompt, inputImages, true);
 
             if (response == null || response.data == null || response.data.isEmpty()) {
                 log.error("OpenAI image edit response is empty");
@@ -153,6 +132,69 @@ public class OpenAiCharacterImageEditClient implements CharacterImageEditClient 
             log.error("OpenAI image edit unexpected failure: {}", e.getMessage(), e);
             throw new ApiException(CharacterErrorCode.CHARACTER_GENERATION_FAILED);
         }
+    }
+
+    private ImageEditResponse requestImageEdit(String prompt, List<SourceImage> inputImages, boolean preferTransparentBackground) {
+        MultiValueMap<String, Object> formData = createImageEditFormData(prompt, inputImages, preferTransparentBackground);
+        try {
+            return openAiRestClient.post()
+                    .uri(IMAGE_EDIT_PATH)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + openAiApiKey)
+                    .body(formData)
+                    .retrieve()
+                    .body(ImageEditResponse.class);
+        } catch (RestClientResponseException e) {
+            if (preferTransparentBackground && shouldRetryWithoutBackground(e)) {
+                log.warn(
+                        "OpenAI image edit rejected transparent background parameter. Retrying without background. status={}, body={}",
+                        e.getStatusCode(),
+                        e.getResponseBodyAsString()
+                );
+                return requestImageEdit(prompt, inputImages, false);
+            }
+            throw e;
+        }
+    }
+
+    private MultiValueMap<String, Object> createImageEditFormData(
+            String prompt,
+            List<SourceImage> inputImages,
+            boolean includeTransparentBackground
+    ) {
+        MultiValueMap<String, Object> formData = new LinkedMultiValueMap<>();
+        formData.add("model", openAiModel);
+        formData.add("prompt", prompt);
+        formData.add("size", openAiSize);
+        formData.add("quality", openAiQuality);
+        formData.add("n", "1");
+        formData.add("output_format", "png");
+        if (includeTransparentBackground) {
+            formData.add("background", TRANSPARENT_BACKGROUND);
+        }
+        for (SourceImage inputImage : inputImages) {
+            HttpHeaders imageHeaders = new HttpHeaders();
+            imageHeaders.setContentType(inputImage.mediaType());
+            HttpEntity<ByteArrayResource> imagePart = new HttpEntity<>(
+                    new NamedByteArrayResource(inputImage.bytes(), inputImage.filename()),
+                    imageHeaders
+            );
+            formData.add("image[]", imagePart);
+        }
+        return formData;
+    }
+
+    private boolean shouldRetryWithoutBackground(RestClientResponseException e) {
+        String responseBody = e.getResponseBodyAsString();
+        if (!StringUtils.hasText(responseBody)) {
+            return false;
+        }
+        String normalizedBody = responseBody.toLowerCase();
+        return normalizedBody.contains("background")
+                && (normalizedBody.contains("unsupported")
+                || normalizedBody.contains("not supported")
+                || normalizedBody.contains("invalid")
+                || normalizedBody.contains("unknown parameter"));
     }
 
     private SimpleClientHttpRequestFactory createRequestFactory(int timeoutMillis) {

--- a/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
+++ b/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
@@ -53,6 +53,10 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
             Pattern.compile("^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", Pattern.DOTALL);
     private static final String DEFAULT_CONTENT_TYPE = MediaType.IMAGE_PNG_VALUE;
     private static final int BACKGROUND_WHITE_THRESHOLD = 245;
+    private static final int STROKE_RESIDUAL_WHITE_THRESHOLD = 235;
+    private static final int STROKE_SOFT_BACKGROUND_THRESHOLD = 220;
+    private static final int STROKE_SOFT_BACKGROUND_ALPHA_THRESHOLD = 96;
+    private static final int MIN_STROKE_ALPHA = 170;
 
     private final String bucket;
     private final String keyPrefix;
@@ -199,6 +203,8 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
                 transparentPixelCount = makeAllBrightPixelsTransparent(alphaImage);
             }
 
+            normalizeForegroundStrokes(alphaImage);
+
             if (transparentPixelCount == 0) {
                 String extension = resolveExtension(contentType);
                 return new StoredImageInput(bytes, contentType, extension);
@@ -286,6 +292,38 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
             }
         }
         return transparentCount;
+    }
+
+    private void normalizeForegroundStrokes(BufferedImage image) {
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int argb = image.getRGB(x, y);
+                int alpha = (argb >> 24) & 0xff;
+                if (alpha == 0) {
+                    continue;
+                }
+
+                int red = (argb >> 16) & 0xff;
+                int green = (argb >> 8) & 0xff;
+                int blue = argb & 0xff;
+                int luminance = (red + green + blue) / 3;
+
+                if (luminance >= STROKE_RESIDUAL_WHITE_THRESHOLD
+                        || (luminance >= STROKE_SOFT_BACKGROUND_THRESHOLD
+                        && alpha <= STROKE_SOFT_BACKGROUND_ALPHA_THRESHOLD)) {
+                    image.setRGB(x, y, 0x00000000);
+                    continue;
+                }
+
+                int darkness = 255 - luminance;
+                int targetAlpha = Math.max(alpha, Math.min(255, darkness * 2));
+                if (luminance < STROKE_SOFT_BACKGROUND_THRESHOLD) {
+                    targetAlpha = Math.max(targetAlpha, MIN_STROKE_ALPHA);
+                }
+
+                image.setRGB(x, y, (targetAlpha << 24));
+            }
+        }
     }
 
     private boolean isBrightBackgroundCandidate(int argb) {

--- a/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
+++ b/src/main/java/com/playlist/plitter/character/infrastructure/s3/S3ImageStorageClient.java
@@ -29,12 +29,20 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 import java.net.URI;
+import java.awt.Point;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayDeque;
 import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.imageio.ImageIO;
 
 @Primary
 @Component
@@ -44,6 +52,7 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
     private static final Pattern DATA_URI_PATTERN =
             Pattern.compile("^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", Pattern.DOTALL);
     private static final String DEFAULT_CONTENT_TYPE = MediaType.IMAGE_PNG_VALUE;
+    private static final int BACKGROUND_WHITE_THRESHOLD = 245;
 
     private final String bucket;
     private final String keyPrefix;
@@ -153,8 +162,7 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
         String contentType = matcher.group(1);
         String base64Data = matcher.group(2);
         byte[] bytes = Base64.getDecoder().decode(base64Data);
-        String extension = resolveExtension(contentType);
-        return new StoredImageInput(bytes, contentType, extension);
+        return normalizeStoredImage(bytes, contentType);
     }
 
     private StoredImageInput downloadRemoteImage(String sourceImageUrl) {
@@ -171,8 +179,127 @@ public class S3ImageStorageClient implements ImageStorageClient, DisposableBean 
         String contentType = response.getHeaders().getContentType() != null
                 ? response.getHeaders().getContentType().toString()
                 : DEFAULT_CONTENT_TYPE;
-        String extension = resolveExtension(contentType);
-        return new StoredImageInput(bytes, contentType, extension);
+        return normalizeStoredImage(bytes, contentType);
+    }
+
+    private StoredImageInput normalizeStoredImage(byte[] bytes, String contentType) {
+        try {
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+            if (image == null) {
+                String extension = resolveExtension(contentType);
+                return new StoredImageInput(bytes, contentType, extension);
+            }
+
+            BufferedImage alphaImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            alphaImage.getGraphics().drawImage(image, 0, 0, null);
+            alphaImage.getGraphics().dispose();
+
+            int transparentPixelCount = makeOuterBrightBackgroundTransparent(alphaImage);
+            if (transparentPixelCount == 0) {
+                transparentPixelCount = makeAllBrightPixelsTransparent(alphaImage);
+            }
+
+            if (transparentPixelCount == 0) {
+                String extension = resolveExtension(contentType);
+                return new StoredImageInput(bytes, contentType, extension);
+            }
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            ImageIO.write(alphaImage, "png", outputStream);
+            return new StoredImageInput(outputStream.toByteArray(), DEFAULT_CONTENT_TYPE, "png");
+        } catch (Exception e) {
+            log.warn("Image background normalization skipped: {}", e.getMessage());
+            String extension = resolveExtension(contentType);
+            return new StoredImageInput(bytes, contentType, extension);
+        }
+    }
+
+    private int makeOuterBrightBackgroundTransparent(BufferedImage image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        ArrayDeque<Point> queue = new ArrayDeque<>();
+        Set<Long> visited = new HashSet<>();
+
+        for (int x = 0; x < width; x++) {
+            enqueueBackgroundPixel(image, queue, visited, x, 0);
+            enqueueBackgroundPixel(image, queue, visited, x, height - 1);
+        }
+        for (int y = 0; y < height; y++) {
+            enqueueBackgroundPixel(image, queue, visited, 0, y);
+            enqueueBackgroundPixel(image, queue, visited, width - 1, y);
+        }
+
+        int transparentCount = 0;
+        while (!queue.isEmpty()) {
+            Point point = queue.removeFirst();
+            int x = point.x;
+            int y = point.y;
+
+            if (!isBrightBackgroundCandidate(image.getRGB(x, y))) {
+                continue;
+            }
+
+            image.setRGB(x, y, 0x00000000);
+            transparentCount++;
+
+            if (x > 0) {
+                enqueueBackgroundPixel(image, queue, visited, x - 1, y);
+            }
+            if (x + 1 < width) {
+                enqueueBackgroundPixel(image, queue, visited, x + 1, y);
+            }
+            if (y > 0) {
+                enqueueBackgroundPixel(image, queue, visited, x, y - 1);
+            }
+            if (y + 1 < height) {
+                enqueueBackgroundPixel(image, queue, visited, x, y + 1);
+            }
+        }
+        return transparentCount;
+    }
+
+    private void enqueueBackgroundPixel(
+            BufferedImage image,
+            ArrayDeque<Point> queue,
+            Set<Long> visited,
+            int x,
+            int y
+    ) {
+        long key = (((long) x) << 32) | (y & 0xffffffffL);
+        if (!visited.add(key)) {
+            return;
+        }
+        if (!isBrightBackgroundCandidate(image.getRGB(x, y))) {
+            return;
+        }
+        queue.addLast(new Point(x, y));
+    }
+
+    private int makeAllBrightPixelsTransparent(BufferedImage image) {
+        int transparentCount = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (isBrightBackgroundCandidate(image.getRGB(x, y))) {
+                    image.setRGB(x, y, 0x00000000);
+                    transparentCount++;
+                }
+            }
+        }
+        return transparentCount;
+    }
+
+    private boolean isBrightBackgroundCandidate(int argb) {
+        int alpha = (argb >> 24) & 0xff;
+        if (alpha == 0) {
+            return true;
+        }
+
+        int red = (argb >> 16) & 0xff;
+        int green = (argb >> 8) & 0xff;
+        int blue = argb & 0xff;
+        return red >= BACKGROUND_WHITE_THRESHOLD
+                && green >= BACKGROUND_WHITE_THRESHOLD
+                && blue >= BACKGROUND_WHITE_THRESHOLD;
     }
 
     private String createObjectKey(Long playlistId, String extension) {


### PR DESCRIPTION
## 📌 관련 이슈
- relates: #86

## 📝 작업 내용
- OpenAI 이미지 편집 요청에 `background=transparent`를 우선 적용
- API가 `background` 파라미터를 거부하면 background 없이 1회 자동 재시도하는 fallback 추가
- S3 저장 직전에 외곽 flood-fill 기반으로 밝은 배경을 alpha로 변환하는 후처리 추가
- flood-fill로 배경이 잡히지 않는 경우 near-white 픽셀 전체를 대상으로 fallback 투명화 적용
- 캐릭터 생성 프롬프트의 배경 규칙을 `transparent background (alpha)` 기준으로 정리

## 🔎 고민한 내용
- 프롬프트만으로는 투명 배경이 안정적으로 생성되지 않아 요청 단계와 저장 단계를 함께 보강했습니다.
- OpenAI API 응답 시간이 30초를 초과하는 케이스가 있어, 검증 시에는 로컬 실행에서 timeout을 120초로 늘려 실제 생성 결과를 확인했습니다.
- 저장 후처리는 단순 색상 치환보다 외곽 flood-fill을 먼저 적용해 캐릭터 내부 흰 영역 오염을 줄이도록 했습니다.

## 💬 기타 참고 사항
- 실제 생성 검증 결과 PNG 알파 채널이 확인됐습니다.
- 검증 샘플에서는 `transparentPixels=965393`, `semiTransparentPixels=60994`, `opaquePixels=22189`로 저장되었습니다.
- 운영 반영 시 OpenAI 호출 timeout 정책은 별도 검토가 필요할 수 있습니다.