### PR TITLE
공유 플레이리스트 public 식별자를 내부 playlistId와 분리

### DIFF
--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -48,7 +48,6 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/kakao/**").permitAll()
                         .requestMatchers("/api/auth/guest").permitAll()
                         .requestMatchers("/auth/logout").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/playlists/*/public").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/playlists/share/*/public").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/playlists/recommendations/*/public").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/playlists/*/recommendations").permitAll()

--- a/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
@@ -19,11 +19,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
+import java.security.SecureRandom;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,6 +31,10 @@ import java.util.stream.Collectors;
 public class PlaylistService {
 
     private static final int REQUIRED_RECOMMENDATION_COUNT_FOR_CHARACTER = 5;
+    private static final String PUBLIC_SHARE_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final int PUBLIC_SHARE_ID_LENGTH = 10;
+    private static final int PUBLIC_SHARE_ID_GENERATION_MAX_ATTEMPTS = 10;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final PlaylistRepository playlistRepository;
     private final UserRepository userRepository;
@@ -47,11 +51,11 @@ public class PlaylistService {
             throw new ApiException(PlaylistErrorCode.PLAYLIST_ALREADY_EXISTS);
         }
 
-        String shortId = UUID.randomUUID().toString().substring(0, 5);
+        String publicShareId = generatePublicShareId();
 
         PlaylistEntity playlist = PlaylistEntity.builder()
                 .owner(user)
-                .shortId(shortId)
+                .shortId(publicShareId)
                 .characterVersion(0)
                 .build();
 
@@ -60,7 +64,7 @@ public class PlaylistService {
         Long playlistId = saved.getId();
         String shareUrl = "https://ourdomain.com/playlist/" + saved.getShortId();
 
-        return new PlaylistCreateResponse(playlistId, shortId, shareUrl);
+        return new PlaylistCreateResponse(playlistId, saved.getShortId(), shareUrl);
     }
 
     @Transactional(readOnly = true)
@@ -93,16 +97,8 @@ public class PlaylistService {
     }
 
     @Transactional(readOnly = true)
-    public PlaylistPublicResponse getPlaylistPublic(Long playlistId) {
-        PlaylistEntity playlist = playlistRepository.findById(playlistId)
-                .orElseThrow(() -> new ApiException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
-
-        return toPlaylistPublicResponse(playlist);
-    }
-
-    @Transactional(readOnly = true)
-    public PlaylistPublicResponse getPlaylistPublicByShortId(String shortId) {
-        PlaylistEntity playlist = playlistRepository.findByShortId(shortId)
+    public PlaylistPublicResponse getPlaylistPublicByPublicShareId(String publicShareId) {
+        PlaylistEntity playlist = playlistRepository.findByShortId(publicShareId)
                 .orElseThrow(() -> new ApiException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         return toPlaylistPublicResponse(playlist);
@@ -117,7 +113,6 @@ public class PlaylistService {
 
         int recommendationCount = recommendations.size();
         return new PlaylistPublicResponse(
-                playlist.getId(),
                 playlist.getShortId(),
                 recommendationCount,
                 recommendationCount >= REQUIRED_RECOMMENDATION_COUNT_FOR_CHARACTER,
@@ -148,6 +143,26 @@ public class PlaylistService {
                     );
                 })
                 .toList();
+    }
+
+    private String generatePublicShareId() {
+        for (int attempt = 0; attempt < PUBLIC_SHARE_ID_GENERATION_MAX_ATTEMPTS; attempt++) {
+            String candidate = randomBase62(PUBLIC_SHARE_ID_LENGTH);
+            if (!playlistRepository.existsByShortId(candidate)) {
+                return candidate;
+            }
+        }
+
+        throw new IllegalStateException("public share id generation failed");
+    }
+
+    private String randomBase62(int length) {
+        StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            int randomIndex = SECURE_RANDOM.nextInt(PUBLIC_SHARE_ID_ALPHABET.length());
+            builder.append(PUBLIC_SHARE_ID_ALPHABET.charAt(randomIndex));
+        }
+        return builder.toString();
     }
 
 }

--- a/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistCreateResponse.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistCreateResponse.java
@@ -2,7 +2,7 @@ package com.playlist.plitter.playlist.application.dto;
 
 public record PlaylistCreateResponse(
         Long playlistId,
-        String shortId,
+        String publicShareId,
         String shareUrl
 ) {
 }

--- a/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistPublicResponse.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistPublicResponse.java
@@ -5,8 +5,7 @@ import com.playlist.plitter.recommendations.application.dto.RecommendationRespon
 import java.util.List;
 
 public record PlaylistPublicResponse(
-        Long playlistId,
-        String shortId,
+        String publicShareId,
         Integer recommendationCount,
         Boolean canCreateCharacter,
         String ownerNickname,

--- a/src/main/java/com/playlist/plitter/playlist/domain/repository/PlaylistRepository.java
+++ b/src/main/java/com/playlist/plitter/playlist/domain/repository/PlaylistRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 @Repository
 public interface PlaylistRepository extends JpaRepository<PlaylistEntity, Long> {
     boolean existsByOwner(UserEntity owner);
+    boolean existsByShortId(String shortId);
     Optional<PlaylistEntity> findByOwnerId(Long ownerId);
     Optional<PlaylistEntity> findByIdAndOwner_Id(Long playlistId, Long ownerId);
     Optional<PlaylistEntity> findByShortId(String shortId);

--- a/src/main/java/com/playlist/plitter/playlist/presentation/PlaylistController.java
+++ b/src/main/java/com/playlist/plitter/playlist/presentation/PlaylistController.java
@@ -46,19 +46,11 @@ public class PlaylistController {
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
 
-    @GetMapping("/playlists/{playlistId}/public")
-    public ResponseDto<PlaylistPublicResponse> getPlaylistPublic(
-            @PathVariable Long playlistId
+    @GetMapping("/playlists/share/{publicShareId}/public")
+    public ResponseDto<PlaylistPublicResponse> getPlaylistPublicByPublicShareId(
+            @PathVariable String publicShareId
     ) {
-        PlaylistPublicResponse response = playlistService.getPlaylistPublic(playlistId);
-        return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
-    }
-
-    @GetMapping("/playlists/share/{shortId}/public")
-    public ResponseDto<PlaylistPublicResponse> getPlaylistPublicByShortId(
-            @PathVariable String shortId
-    ) {
-        PlaylistPublicResponse response = playlistService.getPlaylistPublicByShortId(shortId);
+        PlaylistPublicResponse response = playlistService.getPlaylistPublicByPublicShareId(publicShareId);
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #92

## 📝 작업 내용
- 플레이리스트 생성 시 5자 UUID 조각 대신 10자 base62 공개 ID 발급
- 생성/공개 응답 DTO에서 공개 식별자 필드명을 `publicShareId`로 정리
- 공개 조회 API를 `/api/playlists/share/{publicShareId}/public` 기준으로 통일
- public 응답에서 내부 `playlistId` 제거
- `playlistId` 기반 public permitAll 경로 제거

## 🔎 고민한 내용
- DB 컬럼명은 기존 `short_id`를 유지하고, 외부 계약만 `publicShareId`로 정리해 마이그레이션 부담 없이 내부 ID와 외부 공유 ID를 분리했습니다.

## 💬 기타 참고 사항
- `./gradlew test -q` 통과