### PR TITLE
플레이리스트 check 응답에 publicShareId 추가

### DIFF
--- a/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/PlaylistService.java
@@ -90,10 +90,11 @@ public class PlaylistService {
         Optional<PlaylistEntity> playlist = playlistRepository.findByOwnerId(userId);
 
         if (playlist.isPresent()) {
-            return new PlaylistCheckResponse(true, playlist.get().getId());
+            PlaylistEntity savedPlaylist = playlist.get();
+            return new PlaylistCheckResponse(true, savedPlaylist.getId(), savedPlaylist.getShortId());
         }
 
-        return new PlaylistCheckResponse(false, null);
+        return new PlaylistCheckResponse(false, null, null);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistCheckResponse.java
+++ b/src/main/java/com/playlist/plitter/playlist/application/dto/PlaylistCheckResponse.java
@@ -2,6 +2,7 @@ package com.playlist.plitter.playlist.application.dto;
 
 public record PlaylistCheckResponse(
         boolean hasPlaylist,
-        Long playlistId
+        Long playlistId,
+        String publicShareId
 ) {
 }


### PR DESCRIPTION
## 📌 관련 이슈
- refs: #92

## 📝 작업 내용
- `GET /api/playlists/check` 응답에 `publicShareId` 필드 추가
- 플레이리스트가 존재할 때 owner의 공개 공유 ID를 함께 반환하도록 서비스 로직 보완
- 플레이리스트가 없을 때는 `publicShareId`를 `null`로 반환

## 🔎 고민한 내용
- 프론트가 공개 진입 경로를 `publicShareId` 기준으로 완전히 전환하려면, 인증 상태의 내 플리 확인 응답에서도 동일한 공개 식별자를 받아야 합니다. 그래서 `check` 응답을 최소 범위로 확장했습니다.

## 💬 기타 참고 사항
- `./gradlew test -q` 통과
- 기존 PR #93은 이미 머지되어, 이번 변경은 후속 PR로 분리했습니다.