### PR TITLE
추천 생성 API를 publicShareId 기준으로 확장

### DIFF
--- a/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
+++ b/src/main/java/com/playlist/plitter/global/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/logout").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/playlists/share/*/public").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/playlists/recommendations/*/public").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/playlists/share/*/recommendations").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/playlists/*/recommendations").permitAll()
                         .requestMatchers("/api/tracks/search").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/tracks/*/play").permitAll()

--- a/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
@@ -47,7 +47,25 @@ public class RecommendationsService {
     ) {
         PlaylistEntity playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new RuntimeException("플레이리스트를 찾을 수 없습니다."));
+        return createRecommendation(playlist, recommenderUserId, request);
+    }
 
+    @Transactional
+    public RecommendationCreateResponse createRecommendationByPublicShareId(
+            String publicShareId,
+            Long recommenderUserId,
+            RecommendationCreateRequest request
+    ) {
+        PlaylistEntity playlist = playlistRepository.findByShortId(publicShareId)
+                .orElseThrow(() -> new RuntimeException("플레이리스트를 찾을 수 없습니다."));
+        return createRecommendation(playlist, recommenderUserId, request);
+    }
+
+    private RecommendationCreateResponse createRecommendation(
+            PlaylistEntity playlist,
+            Long recommenderUserId,
+            RecommendationCreateRequest request
+    ) {
         UserEntity recommenderUser = null;
         String guestToken = request.guestToken();
         String randomNickname = null;

--- a/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/RecommendationsService.java
@@ -134,7 +134,6 @@ public class RecommendationsService {
 
         return new RecommendationCreateResponse(
                 savedRecommendation.getId(),
-                playlist.getId(),
                 savedRecommendation.getCreatedAt()
         );
     }

--- a/src/main/java/com/playlist/plitter/recommendations/application/dto/RecommendationCreateResponse.java
+++ b/src/main/java/com/playlist/plitter/recommendations/application/dto/RecommendationCreateResponse.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 public record RecommendationCreateResponse(
         Long recommendationId,
-        Long playlistId,
         LocalDateTime createdAt
 ) {
 

--- a/src/main/java/com/playlist/plitter/recommendations/presentation/RecommendationsController.java
+++ b/src/main/java/com/playlist/plitter/recommendations/presentation/RecommendationsController.java
@@ -27,6 +27,20 @@ public class RecommendationsController {
         return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
     }
 
+    @PostMapping("/share/{publicShareId}/recommendations")
+    public ResponseDto<RecommendationCreateResponse> createRecommendationByPublicShareId(
+            @PathVariable String publicShareId,
+            @AuthenticationPrincipal Long recommenderUserId,
+            @RequestBody RecommendationCreateRequest request
+    ) {
+        RecommendationCreateResponse response = recommendationsService.createRecommendationByPublicShareId(
+                publicShareId,
+                recommenderUserId,
+                request
+        );
+        return ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response);
+    }
+
     @GetMapping("/recommendations/{recommendationId}")
     public ResponseDto<RecommendationDetailResponse> getRecommendationDetail(
             @PathVariable Long recommendationId


### PR DESCRIPTION
## 📌 관련 이슈
- refs: #92

## 📝 작업 내용
- `POST /api/playlists/share/{publicShareId}/recommendations` 추가
- 추천 생성 로직을 playlist 엔티티 기준 private 메서드로 분리해 `playlistId`/`publicShareId` 경로 모두 재사용
- `publicShareId` 추천 생성 경로를 `permitAll`로 허용

## 🔎 고민한 내용
- 내부 `playlistId` 기반 생성 API는 유지하고, 공개 공유 진입에서만 새 `publicShareId` 경로를 사용하도록 병행 추가했습니다. 이렇게 하면 프론트는 공개 플로우만 전환하면 되고 기존 내부 동선과 충돌하지 않습니다.

## 💬 기타 참고 사항
- `./gradlew test -q` 통과
- 기존 PR #93, #94는 이미 머지되어 이번 작업은 별도 후속 PR로 분리했습니다.